### PR TITLE
feat: Field component family (#36)

### DIFF
--- a/app/views/kiso/components/_field.html.erb
+++ b/app/views/kiso/components/_field.html.erb
@@ -1,0 +1,12 @@
+<%# locals: (orientation: :vertical, invalid: false, disabled: false, css_classes: "", **component_options) %>
+<%= content_tag :div,
+    role: :group,
+    class: Kiso::Themes::Field.render(orientation: orientation, class: css_classes),
+    data: kiso_prepare_options(component_options, component: :field).merge(
+      orientation: orientation,
+      invalid: (true if invalid),
+      disabled: (true if disabled)
+    ).compact,
+    **component_options do %>
+  <%= yield %>
+<% end %>

--- a/app/views/kiso/components/_field_group.html.erb
+++ b/app/views/kiso/components/_field_group.html.erb
@@ -1,0 +1,7 @@
+<%# locals: (css_classes: "", **component_options) %>
+<%= content_tag :div,
+    class: Kiso::Themes::FieldGroup.render(class: css_classes),
+    data: kiso_prepare_options(component_options, component: :field_group),
+    **component_options do %>
+  <%= yield %>
+<% end %>

--- a/app/views/kiso/components/_field_set.html.erb
+++ b/app/views/kiso/components/_field_set.html.erb
@@ -1,0 +1,7 @@
+<%# locals: (css_classes: "", **component_options) %>
+<%= content_tag :fieldset,
+    class: Kiso::Themes::FieldSet.render(class: css_classes),
+    data: kiso_prepare_options(component_options, component: :field_set),
+    **component_options do %>
+  <%= yield %>
+<% end %>

--- a/app/views/kiso/components/_label.html.erb
+++ b/app/views/kiso/components/_label.html.erb
@@ -1,0 +1,5 @@
+<%# locals: (css_classes: "", **component_options) %>
+<%= tag.label(
+    class: Kiso::Themes::Label.render(class: css_classes),
+    data: kiso_prepare_options(component_options, component: :label),
+    **component_options) { yield } %>

--- a/app/views/kiso/components/field/_content.html.erb
+++ b/app/views/kiso/components/field/_content.html.erb
@@ -1,0 +1,7 @@
+<%# locals: (css_classes: "", **component_options) %>
+<%= content_tag :div,
+    class: Kiso::Themes::FieldContent.render(class: css_classes),
+    data: kiso_prepare_options(component_options, component: :field, field_part: :content),
+    **component_options do %>
+  <%= yield %>
+<% end %>

--- a/app/views/kiso/components/field/_description.html.erb
+++ b/app/views/kiso/components/field/_description.html.erb
@@ -1,0 +1,7 @@
+<%# locals: (css_classes: "", **component_options) %>
+<%= content_tag :p,
+    class: Kiso::Themes::FieldDescription.render(class: css_classes),
+    data: kiso_prepare_options(component_options, component: :field, field_part: :description),
+    **component_options do %>
+  <%= yield %>
+<% end %>

--- a/app/views/kiso/components/field/_error.html.erb
+++ b/app/views/kiso/components/field/_error.html.erb
@@ -1,0 +1,22 @@
+<%# locals: (errors: [], css_classes: "", **component_options) %>
+<% messages = Array(errors).compact.map(&:to_s).reject(&:blank?).uniq %>
+<% content = capture { yield }.presence %>
+<% if content || messages.any? %>
+  <%= content_tag :div,
+      role: :alert,
+      class: Kiso::Themes::FieldError.render(class: css_classes),
+      data: kiso_prepare_options(component_options, component: :field, field_part: :error),
+      **component_options do %>
+    <% if content %>
+      <%= content %>
+    <% elsif messages.one? %>
+      <%= messages.first %>
+    <% else %>
+      <ul class="ml-4 flex list-disc flex-col gap-1">
+        <% messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/kiso/components/field/_label.html.erb
+++ b/app/views/kiso/components/field/_label.html.erb
@@ -1,0 +1,5 @@
+<%# locals: (css_classes: "", **component_options) %>
+<% component_options[:data] = (component_options[:data] || {}).merge(field_part: :label) %>
+<%= kiso(:label,
+    css_classes: Kiso::Themes::FieldLabel.render(class: css_classes),
+    **component_options) { yield } %>

--- a/app/views/kiso/components/field/_separator.html.erb
+++ b/app/views/kiso/components/field/_separator.html.erb
@@ -1,0 +1,15 @@
+<%# locals: (css_classes: "", **component_options) %>
+<% captured = capture { yield } if block_given? %>
+<%= content_tag :div,
+    class: Kiso::Themes::FieldSeparator.render(class: css_classes),
+    data: kiso_prepare_options(component_options, component: :field, field_part: :separator).merge(
+      content: captured&.present? || nil
+    ).compact,
+    **component_options do %>
+  <%= kiso(:separator, css_classes: "absolute inset-0 top-1/2") %>
+  <% if captured&.present? %>
+    <span class="<%= Kiso::Themes::FieldSeparatorText.render %>">
+      <%= captured %>
+    </span>
+  <% end %>
+<% end %>

--- a/app/views/kiso/components/field/_title.html.erb
+++ b/app/views/kiso/components/field/_title.html.erb
@@ -1,0 +1,7 @@
+<%# locals: (css_classes: "", **component_options) %>
+<%= content_tag :div,
+    class: Kiso::Themes::FieldTitle.render(class: css_classes),
+    data: kiso_prepare_options(component_options, component: :field, field_part: :title),
+    **component_options do %>
+  <%= yield %>
+<% end %>

--- a/app/views/kiso/components/field_set/_legend.html.erb
+++ b/app/views/kiso/components/field_set/_legend.html.erb
@@ -1,0 +1,9 @@
+<%# locals: (variant: :legend, css_classes: "", **component_options) %>
+<%= content_tag :legend,
+    class: Kiso::Themes::FieldLegend.render(variant: variant, class: css_classes),
+    data: kiso_prepare_options(component_options, component: :field_set, field_set_part: :legend).merge(
+      variant: variant
+    ),
+    **component_options do %>
+  <%= yield %>
+<% end %>

--- a/docs/src/components/field.md
+++ b/docs/src/components/field.md
@@ -1,0 +1,259 @@
+---
+title: Field
+layout: docs
+description: Composable form field wrappers for labels, descriptions, errors, and layout.
+category: Forms
+source: lib/kiso/themes/field.rb
+---
+
+## Quick Start
+
+```erb
+<%%= kiso(:field) do %>
+  <%%= kiso(:field, :label, for: :email) { "Email address" } %>
+  <%%= kiso(:input, type: :email, id: :email, name: :email) %>
+  <%%= kiso(:field, :description) { "We'll never share your email." } %>
+  <%%= kiso(:field, :error) { @user.errors[:email].first } %>
+<%% end %>
+```
+
+<%= render "component_preview", component: "kiso/field", scenario: "playground", height: "300px" %>
+
+## Locals
+
+### Field
+
+| Local | Type | Default |
+|-------|------|---------|
+| `orientation:` | `:vertical` \| `:horizontal` \| `:responsive` | `:vertical` |
+| `invalid:` | Boolean | `false` |
+| `disabled:` | Boolean | `false` |
+| `css_classes:` | String | `""` |
+| `**component_options` | Hash | `{}` |
+
+### FieldGroup
+
+| Local | Type | Default |
+|-------|------|---------|
+| `css_classes:` | String | `""` |
+| `**component_options` | Hash | `{}` |
+
+### FieldSet
+
+| Local | Type | Default |
+|-------|------|---------|
+| `css_classes:` | String | `""` |
+| `**component_options` | Hash | `{}` |
+
+### FieldLegend
+
+| Local | Type | Default |
+|-------|------|---------|
+| `variant:` | `:legend` \| `:label` | `:legend` |
+| `css_classes:` | String | `""` |
+| `**component_options` | Hash | `{}` |
+
+### FieldError
+
+| Local | Type | Default |
+|-------|------|---------|
+| `errors:` | Array | `[]` |
+| `css_classes:` | String | `""` |
+| `**component_options` | Hash | `{}` |
+
+## Sub-parts
+
+| Part | Usage | Element | Purpose |
+|------|-------|---------|---------|
+| `:label` | `kiso(:field, :label)` | `<label>` | Accessible label (wraps Label component) |
+| `:content` | `kiso(:field, :content)` | `<div>` | Groups label + description in a flex column |
+| `:title` | `kiso(:field, :title)` | `<div>` | Lightweight title (alternative to label) |
+| `:description` | `kiso(:field, :description)` | `<p>` | Helper text below field |
+| `:error` | `kiso(:field, :error)` | `<div role="alert">` | Error message (only renders when content present) |
+| `:separator` | `kiso(:field, :separator)` | `<div>` | Visual divider with optional text |
+
+FieldSet sub-parts:
+
+| Part | Usage | Element | Purpose |
+|------|-------|---------|---------|
+| `:legend` | `kiso(:field_set, :legend)` | `<legend>` | Semantic legend with variant styling |
+
+All sub-parts accept `css_classes:` and `**component_options`.
+
+## Anatomy
+
+```
+FieldGroup
+├── Field (vertical)
+│   ├── Field Label
+│   ├── <input>
+│   ├── Field Description
+│   └── Field Error
+├── Field Separator
+└── Field (horizontal)
+    ├── <checkbox>
+    └── Field Content
+        ├── Field Label
+        └── Field Description
+
+FieldSet
+├── FieldSet Legend
+├── Field Description
+└── Field (horizontal) × N
+```
+
+## Usage
+
+### Vertical (default)
+
+The standard layout — label above input, full width.
+
+```erb
+<%%= kiso(:field) do %>
+  <%%= kiso(:field, :label, for: :name) { "Full name" } %>
+  <%%= kiso(:input, id: :name, name: :name) %>
+  <%%= kiso(:field, :description) { "As it appears on your ID." } %>
+<%% end %>
+```
+
+### Horizontal
+
+Label and control side by side — ideal for checkboxes, radios, and switches.
+
+```erb
+<%%= kiso(:field, orientation: :horizontal) do %>
+  <%%= kiso(:checkbox, id: :dark_mode, name: :dark_mode) %>
+  <%%= kiso(:field, :label, for: :dark_mode) { "Enable dark mode" } %>
+<%% end %>
+```
+
+With description using FieldContent:
+
+```erb
+<%%= kiso(:field, orientation: :horizontal) do %>
+  <%%= kiso(:checkbox, id: :newsletter, name: :newsletter) %>
+  <%%= kiso(:field, :content) do %>
+    <%%= kiso(:field, :label, for: :newsletter) { "Newsletter" } %>
+    <%%= kiso(:field, :description) { "Receive weekly updates." } %>
+  <%% end %>
+<%% end %>
+```
+
+### Responsive
+
+Stacks vertically on mobile, switches to horizontal at the `@md` container
+query breakpoint. Requires a parent FieldGroup for the container query scope.
+
+```erb
+<%%= kiso(:field_group) do %>
+  <%%= kiso(:field, orientation: :responsive) do %>
+    <%%= kiso(:field, :label, for: :company) { "Company" } %>
+    <%%= kiso(:input, id: :company, name: :company) %>
+  <%% end %>
+<%% end %>
+```
+
+### Validation Errors
+
+Set `invalid: true` on the field to apply error styling. Use FieldError to
+display messages — it only renders when content is present.
+
+```erb
+<%%= kiso(:field, invalid: true) do %>
+  <%%= kiso(:field, :label, for: :email) { "Email" } %>
+  <%%= kiso(:input, id: :email, name: :email) %>
+  <%%= kiso(:field, :error) { "Please enter a valid email." } %>
+<%% end %>
+```
+
+Pass Rails model errors directly via the `errors:` prop. Single errors render
+as text; multiple errors render as a bulleted list:
+
+```erb
+<%%= kiso(:field, :error, errors: @user.errors[:email]) %>
+```
+
+### FieldGroup
+
+Stacks multiple fields with consistent `gap-7` spacing.
+
+```erb
+<%%= kiso(:field_group) do %>
+  <%%= kiso(:field) do %>
+    <%%= kiso(:field, :label, for: :first_name) { "First name" } %>
+    <%%= kiso(:input, id: :first_name, name: :first_name) %>
+  <%% end %>
+  <%%= kiso(:field) do %>
+    <%%= kiso(:field, :label, for: :last_name) { "Last name" } %>
+    <%%= kiso(:input, id: :last_name, name: :last_name) %>
+  <%% end %>
+<%% end %>
+```
+
+### FieldSet
+
+Semantic `<fieldset>` for grouping related controls (checkboxes, radios).
+
+```erb
+<%%= kiso(:field_set) do %>
+  <%%= kiso(:field_set, :legend) { "Notifications" } %>
+  <%%= kiso(:field, orientation: :horizontal) do %>
+    <%%= kiso(:checkbox, id: :email_notifs, name: "notifs[]", value: "email") %>
+    <%%= kiso(:field, :label, for: :email_notifs) { "Email" } %>
+  <%% end %>
+  <%%= kiso(:field, orientation: :horizontal) do %>
+    <%%= kiso(:checkbox, id: :sms_notifs, name: "notifs[]", value: "sms") %>
+    <%%= kiso(:field, :label, for: :sms_notifs) { "SMS" } %>
+  <%% end %>
+<%% end %>
+```
+
+### FieldSeparator
+
+Visual divider between fields, with optional centered text.
+
+```erb
+<%%= kiso(:field, :separator) { "Or continue with" } %>
+```
+
+## Theme
+
+```ruby
+# Field — orientation variants
+Kiso::Themes::Field = ClassVariants.build(
+  base: "group/field flex w-full gap-3 text-foreground data-[invalid=true]:text-error",
+  variants: {
+    orientation: {
+      vertical: "flex-col [&>*]:w-full [&>.sr-only]:w-auto",
+      horizontal: "flex-row items-center ...",
+      responsive: "flex-col ... @md/field-group:flex-row ..."
+    }
+  },
+  defaults: { orientation: :vertical }
+)
+
+# FieldGroup — container query scope
+Kiso::Themes::FieldGroup = ClassVariants.build(
+  base: "group/field-group @container/field-group flex w-full flex-col gap-7 ..."
+)
+
+# FieldSet + FieldLegend
+Kiso::Themes::FieldSet = ClassVariants.build(
+  base: "flex flex-col gap-6 ..."
+)
+
+Kiso::Themes::FieldLegend = ClassVariants.build(
+  base: "mb-3 font-medium",
+  variants: { variant: { legend: "text-base", label: "text-sm" } },
+  defaults: { variant: :legend }
+)
+```
+
+## Accessibility
+
+- Field renders `<div role="group">` with `data-orientation` attribute
+- FieldLabel renders `<label>` with proper `for` attribute linking
+- FieldError renders `<div role="alert">` for screen reader announcements
+- FieldSet renders semantic `<fieldset>` with `<legend>`
+- `invalid: true` sets `data-invalid="true"` which cascades error color
+- `disabled: true` sets `data-disabled="true"` which dims labels via group styling

--- a/lib/kiso.rb
+++ b/lib/kiso.rb
@@ -11,6 +11,10 @@ require "kiso/themes/empty"
 require "kiso/themes/stats_card"
 require "kiso/themes/table"
 require "kiso/themes/pagination"
+require "kiso/themes/label"
+require "kiso/themes/field"
+require "kiso/themes/field_group"
+require "kiso/themes/field_set"
 require "kiso/icons"
 
 module Kiso

--- a/lib/kiso/themes/field.rb
+++ b/lib/kiso/themes/field.rb
@@ -1,0 +1,71 @@
+module Kiso
+  module Themes
+    # shadcn: group/field flex w-full gap-3 data-[invalid=true]:text-destructive
+    #         + orientation variants (vertical/horizontal/responsive)
+    Field = ClassVariants.build(
+      base: "group/field flex w-full gap-3 text-foreground data-[invalid=true]:text-error",
+      variants: {
+        orientation: {
+          vertical: "flex-col [&>*]:w-full [&>.sr-only]:w-auto",
+          horizontal: "flex-row items-center " \
+                      "[&>[data-field-part=label]]:flex-auto " \
+                      "has-[>[data-field-part=content]]:items-start " \
+                      "has-[>[data-field-part=content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+          responsive: "flex-col [&>*]:w-full [&>.sr-only]:w-auto " \
+                      "@md/field-group:flex-row @md/field-group:items-center @md/field-group:[&>*]:w-auto " \
+                      "@md/field-group:[&>[data-field-part=label]]:flex-auto " \
+                      "@md/field-group:has-[>[data-field-part=content]]:items-start " \
+                      "@md/field-group:has-[>[data-field-part=content]]:[&>[role=checkbox],[role=radio]]:mt-px"
+        }
+      },
+      defaults: {orientation: :vertical}
+    )
+
+    # shadcn: group/field-content flex flex-1 flex-col gap-1.5 leading-snug
+    FieldContent = ClassVariants.build(
+      base: "group/field-content flex flex-1 flex-col gap-1.5 leading-snug"
+    )
+
+    # shadcn: group/field-label peer/field-label flex w-fit gap-2 leading-snug
+    #         group-data-[disabled=true]/field:opacity-50
+    #         + checkbox/radio container classes (dormant until those components exist)
+    FieldLabel = ClassVariants.build(
+      base: "group/field-label peer/field-label flex w-fit gap-2 leading-snug " \
+            "group-data-[disabled=true]/field:opacity-50 " \
+            "has-[>[data-component=field]]:w-full has-[>[data-component=field]]:flex-col " \
+            "has-[>[data-component=field]]:rounded-md has-[>[data-component=field]]:border " \
+            "[&>*[data-component=field]]:p-4"
+    )
+
+    # shadcn: flex w-fit items-center gap-2 text-sm leading-snug font-medium
+    #         group-data-[disabled=true]/field:opacity-50
+    FieldTitle = ClassVariants.build(
+      base: "flex w-fit items-center gap-2 text-sm leading-snug font-medium " \
+            "group-data-[disabled=true]/field:opacity-50"
+    )
+
+    # shadcn: text-muted-foreground text-sm leading-normal font-normal
+    #         + horizontal text-balance, spacing adjustments, link styling
+    FieldDescription = ClassVariants.build(
+      base: "text-muted-foreground text-sm leading-normal font-normal " \
+            "group-has-[[data-orientation=horizontal]]/field:text-balance " \
+            "last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&]:-mt-1.5 " \
+            "[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4"
+    )
+
+    # shadcn: text-destructive text-sm font-normal
+    FieldError = ClassVariants.build(
+      base: "text-error text-sm font-normal"
+    )
+
+    # shadcn: relative -my-2 h-5 text-sm
+    FieldSeparator = ClassVariants.build(
+      base: "relative -my-2 h-5 text-sm"
+    )
+
+    # shadcn: bg-background text-muted-foreground relative mx-auto block w-fit px-2
+    FieldSeparatorText = ClassVariants.build(
+      base: "bg-background text-muted-foreground relative mx-auto block w-fit px-2"
+    )
+  end
+end

--- a/lib/kiso/themes/field_group.rb
+++ b/lib/kiso/themes/field_group.rb
@@ -1,0 +1,10 @@
+module Kiso
+  module Themes
+    # shadcn: group/field-group @container/field-group flex w-full flex-col gap-7
+    #         [&>[data-slot=field-group]]:gap-4
+    FieldGroup = ClassVariants.build(
+      base: "group/field-group @container/field-group flex w-full flex-col gap-7 " \
+            "[&>[data-component=field_group]]:gap-4"
+    )
+  end
+end

--- a/lib/kiso/themes/field_set.rb
+++ b/lib/kiso/themes/field_set.rb
@@ -1,0 +1,23 @@
+module Kiso
+  module Themes
+    # shadcn: flex flex-col gap-6
+    #         has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3
+    FieldSet = ClassVariants.build(
+      base: "flex flex-col gap-6 " \
+            "has-[>[data-component=checkbox_group]]:gap-3 " \
+            "has-[>[data-component=radio_group]]:gap-3"
+    )
+
+    # shadcn: mb-3 font-medium + variant (legend: text-base, label: text-sm)
+    FieldLegend = ClassVariants.build(
+      base: "mb-3 font-medium",
+      variants: {
+        variant: {
+          legend: "text-base",
+          label: "text-sm"
+        }
+      },
+      defaults: {variant: :legend}
+    )
+  end
+end

--- a/lib/kiso/themes/label.rb
+++ b/lib/kiso/themes/label.rb
@@ -1,0 +1,12 @@
+module Kiso
+  module Themes
+    # shadcn: flex items-center gap-2 text-sm leading-none font-medium select-none
+    #         group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50
+    #         peer-disabled:cursor-not-allowed peer-disabled:opacity-50
+    Label = ClassVariants.build(
+      base: "flex items-center gap-2 text-sm leading-none font-medium select-none " \
+            "group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 " \
+            "peer-disabled:cursor-not-allowed peer-disabled:opacity-50"
+    )
+  end
+end

--- a/skills/kiso/references/components.md
+++ b/skills/kiso/references/components.md
@@ -44,6 +44,87 @@ or vertical.
 
 **Theme module:** `Kiso::Themes::Separator` (`lib/kiso/themes/separator.rb`)
 
+## Forms
+
+| Component | Key locals |
+|---|---|
+| `field` | `orientation` (vertical/horizontal/responsive), `invalid`, `disabled` |
+| `field_group` | No variants. Container for stacking fields with gap-7 spacing |
+| `field_set` | No variants. Semantic `<fieldset>` for checkbox/radio groups |
+| `label` | No variants. Styled `<label>` element |
+
+### Field
+
+Composable form field wrapper. Provides accessible structure for labels,
+descriptions, errors, and layout orientation.
+
+**Locals:** `orientation:` (vertical, horizontal, responsive), `invalid:` (true/false), `disabled:` (true/false), `css_classes:`, `**component_options`
+
+**Defaults:** `orientation: :vertical, invalid: false, disabled: false`
+
+**Sub-parts:** `kiso(:field, :label)`, `kiso(:field, :content)`, `kiso(:field, :title)`, `kiso(:field, :description)`, `kiso(:field, :error)`, `kiso(:field, :separator)`
+
+```erb
+<%# Vertical field (default) %>
+<%= kiso(:field) do %>
+  <%= kiso(:field, :label, for: :email) { "Email" } %>
+  <%= kiso(:input, id: :email, name: :email) %>
+  <%= kiso(:field, :description) { "We'll never share your email." } %>
+  <%= kiso(:field, :error, errors: @user.errors[:email]) %>
+<% end %>
+
+<%# Horizontal (checkbox/switch layout) %>
+<%= kiso(:field, orientation: :horizontal) do %>
+  <%= kiso(:checkbox, id: :terms) %>
+  <%= kiso(:field, :label, for: :terms) { "Accept terms" } %>
+<% end %>
+```
+
+**FieldError:** Only renders when content is present. Accepts `errors:` array (Rails model errors) or block content. Multiple errors render as a bulleted list.
+
+**Theme modules:** `Kiso::Themes::Field`, `FieldContent`, `FieldLabel`, `FieldTitle`, `FieldDescription`, `FieldError`, `FieldSeparator`, `FieldSeparatorText` (`lib/kiso/themes/field.rb`)
+
+### FieldGroup
+
+Stacks multiple fields with `gap-7` spacing. Provides `@container/field-group` scope for responsive Field orientation.
+
+```erb
+<%= kiso(:field_group) do %>
+  <%= kiso(:field) do %>...<% end %>
+  <%= kiso(:field) do %>...<% end %>
+<% end %>
+```
+
+**Theme module:** `Kiso::Themes::FieldGroup` (`lib/kiso/themes/field_group.rb`)
+
+### FieldSet
+
+Semantic `<fieldset>` for grouping related controls.
+
+**Sub-parts:** `kiso(:field_set, :legend)` — accepts `variant:` (legend, label)
+
+```erb
+<%= kiso(:field_set) do %>
+  <%= kiso(:field_set, :legend) { "Notifications" } %>
+  <%= kiso(:field, orientation: :horizontal) do %>
+    <%= kiso(:checkbox, id: :email_notifs) %>
+    <%= kiso(:field, :label, for: :email_notifs) { "Email" } %>
+  <% end %>
+<% end %>
+```
+
+**Theme modules:** `Kiso::Themes::FieldSet`, `FieldLegend` (`lib/kiso/themes/field_set.rb`)
+
+### Label
+
+Styled `<label>` element with disabled state handling. Used internally by FieldLabel.
+
+```erb
+<%= kiso(:label, for: :email) { "Email address" } %>
+```
+
+**Theme module:** `Kiso::Themes::Label` (`lib/kiso/themes/label.rb`)
+
 ## Element
 
 | Component | Key locals |

--- a/test/components/previews/kiso/field_preview.rb
+++ b/test/components/previews/kiso/field_preview.rb
@@ -1,0 +1,54 @@
+module Kiso
+  # @label Field
+  class FieldPreview < Lookbook::Preview
+    # @label Input
+    def input
+      render_with_template
+    end
+
+    # @label Textarea
+    def textarea
+      render_with_template
+    end
+
+    # @label Select
+    def select
+      render_with_template
+    end
+
+    # @label Fieldset
+    def fieldset
+      render_with_template
+    end
+
+    # @label Checkbox
+    def checkbox
+      render_with_template
+    end
+
+    # @label Radio
+    def radio
+      render_with_template
+    end
+
+    # @label Switch
+    def switch
+      render_with_template
+    end
+
+    # @label Choice Card
+    def choice_card
+      render_with_template
+    end
+
+    # @label Field Group
+    def field_group
+      render_with_template
+    end
+
+    # @label Responsive
+    def responsive
+      render_with_template
+    end
+  end
+end

--- a/test/components/previews/kiso/field_preview/checkbox.html.erb
+++ b/test/components/previews/kiso/field_preview/checkbox.html.erb
@@ -1,0 +1,33 @@
+<div class="max-w-sm">
+  <%= kiso(:field_set) do %>
+    <%= kiso(:field_set, :legend, variant: :label) { "Show on desktop" } %>
+    <%= kiso(:field, :description) { "Select the items you want to display on your dashboard." } %>
+
+    <%= kiso(:field, orientation: :horizontal) do %>
+      <input type="checkbox" id="cb_recents" name="items[]" value="recents" checked role="checkbox"
+        class="size-4 rounded border accent-primary">
+      <%= kiso(:field, :content) do %>
+        <%= kiso(:field, :label, for: :cb_recents) { "Recents" } %>
+        <%= kiso(:field, :description) { "Shows your most recent activity." } %>
+      <% end %>
+    <% end %>
+
+    <%= kiso(:field, orientation: :horizontal) do %>
+      <input type="checkbox" id="cb_home" name="items[]" value="home" role="checkbox"
+        class="size-4 rounded border accent-primary">
+      <%= kiso(:field, :content) do %>
+        <%= kiso(:field, :label, for: :cb_home) { "Home" } %>
+        <%= kiso(:field, :description) { "Shows your home dashboard." } %>
+      <% end %>
+    <% end %>
+
+    <%= kiso(:field, orientation: :horizontal) do %>
+      <input type="checkbox" id="cb_apps" name="items[]" value="apps" role="checkbox"
+        class="size-4 rounded border accent-primary">
+      <%= kiso(:field, :content) do %>
+        <%= kiso(:field, :label, for: :cb_apps) { "Applications" } %>
+        <%= kiso(:field, :description) { "Shows your installed applications." } %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/test/components/previews/kiso/field_preview/choice_card.html.erb
+++ b/test/components/previews/kiso/field_preview/choice_card.html.erb
@@ -1,0 +1,27 @@
+<div class="max-w-md">
+  <%= kiso(:field_set) do %>
+    <%= kiso(:field_set, :legend, variant: :label) { "Compute Environment" } %>
+    <%= kiso(:field, :description) { "Select the compute environment for your workload." } %>
+
+    <%# Choice card: radio wrapped in a label-styled card %>
+    <div class="space-y-3">
+      <label class="flex w-full cursor-pointer flex-row items-start gap-3 rounded-md border p-4 has-[:checked]:border-primary has-[:checked]:bg-primary/5">
+        <input type="radio" id="env_k8s" name="environment" value="kubernetes" role="radio"
+          class="mt-0.5 size-4 accent-primary" checked>
+        <div class="flex flex-1 flex-col gap-1.5 leading-snug">
+          <span class="flex w-fit items-center gap-2 text-sm leading-snug font-medium">Kubernetes</span>
+          <p class="text-muted-foreground text-sm leading-normal font-normal">Deploy to a managed Kubernetes cluster with auto-scaling.</p>
+        </div>
+      </label>
+
+      <label class="flex w-full cursor-pointer flex-row items-start gap-3 rounded-md border p-4 has-[:checked]:border-primary has-[:checked]:bg-primary/5">
+        <input type="radio" id="env_vm" name="environment" value="vm" role="radio"
+          class="mt-0.5 size-4 accent-primary">
+        <div class="flex flex-1 flex-col gap-1.5 leading-snug">
+          <span class="flex w-fit items-center gap-2 text-sm leading-snug font-medium">Virtual Machine</span>
+          <p class="text-muted-foreground text-sm leading-normal font-normal">Traditional VM with full OS access and custom configuration.</p>
+        </div>
+      </label>
+    </div>
+  <% end %>
+</div>

--- a/test/components/previews/kiso/field_preview/field_group.html.erb
+++ b/test/components/previews/kiso/field_preview/field_group.html.erb
@@ -1,0 +1,45 @@
+<div class="max-w-md">
+  <%= kiso(:field_set) do %>
+    <%= kiso(:field_set, :legend) { "Responses" } %>
+    <%= kiso(:field, :description) { "Manage how you receive form responses." } %>
+
+    <%= kiso(:field_group) do %>
+      <%= kiso(:field, orientation: :horizontal) do %>
+        <label class="relative inline-flex h-5 w-9 cursor-pointer items-center rounded-full bg-muted transition-colors has-[:checked]:bg-primary">
+          <input type="checkbox" id="email_resp" class="peer sr-only" role="switch" checked>
+          <span class="pointer-events-none block size-4 translate-x-0.5 rounded-full bg-background shadow-sm transition-transform peer-checked:translate-x-[18px]"></span>
+        </label>
+        <%= kiso(:field, :content) do %>
+          <%= kiso(:field, :label, for: :email_resp) { "Email notifications" } %>
+          <%= kiso(:field, :description) { "Receive email for each new response." } %>
+        <% end %>
+      <% end %>
+
+      <%= kiso(:field, :separator) { "Or" } %>
+
+      <%= kiso(:field, orientation: :horizontal) do %>
+        <label class="relative inline-flex h-5 w-9 cursor-pointer items-center rounded-full bg-muted transition-colors has-[:checked]:bg-primary">
+          <input type="checkbox" id="webhook_resp" class="peer sr-only" role="switch">
+          <span class="pointer-events-none block size-4 translate-x-0.5 rounded-full bg-background shadow-sm transition-transform peer-checked:translate-x-[18px]"></span>
+        </label>
+        <%= kiso(:field, :content) do %>
+          <%= kiso(:field, :label, for: :webhook_resp) { "Webhook" } %>
+          <%= kiso(:field, :description) { "Send responses to a webhook URL." } %>
+        <% end %>
+      <% end %>
+
+      <%= kiso(:field, :separator) %>
+
+      <%= kiso(:field, orientation: :horizontal) do %>
+        <label class="relative inline-flex h-5 w-9 cursor-pointer items-center rounded-full bg-muted transition-colors has-[:checked]:bg-primary">
+          <input type="checkbox" id="slack_resp" class="peer sr-only" role="switch">
+          <span class="pointer-events-none block size-4 translate-x-0.5 rounded-full bg-background shadow-sm transition-transform peer-checked:translate-x-[18px]"></span>
+        </label>
+        <%= kiso(:field, :content) do %>
+          <%= kiso(:field, :label, for: :slack_resp) { "Slack integration" } %>
+          <%= kiso(:field, :description) { "Post responses to a Slack channel." } %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/test/components/previews/kiso/field_preview/fieldset.html.erb
+++ b/test/components/previews/kiso/field_preview/fieldset.html.erb
@@ -1,0 +1,26 @@
+<div class="max-w-md">
+  <%= kiso(:field_set) do %>
+    <%= kiso(:field_set, :legend) { "Address Information" } %>
+    <%= kiso(:field, :description) { "Enter your billing address." } %>
+
+    <%= kiso(:field_group) do %>
+      <%= kiso(:field) do %>
+        <%= kiso(:field, :label, for: :street) { "Street address" } %>
+        <input type="text" id="street" name="street" placeholder="123 Main St"
+          class="flex h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+      <% end %>
+
+      <%= kiso(:field) do %>
+        <%= kiso(:field, :label, for: :city) { "City" } %>
+        <input type="text" id="city" name="city" placeholder="San Francisco"
+          class="flex h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+      <% end %>
+
+      <%= kiso(:field) do %>
+        <%= kiso(:field, :label, for: :postal) { "Postal code" } %>
+        <input type="text" id="postal" name="postal" placeholder="94103"
+          class="flex h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/test/components/previews/kiso/field_preview/input.html.erb
+++ b/test/components/previews/kiso/field_preview/input.html.erb
@@ -1,0 +1,18 @@
+<div class="max-w-sm space-y-8">
+  <%# Basic input with description %>
+  <%= kiso(:field) do %>
+    <%= kiso(:field, :label, for: :username) { "Username" } %>
+    <input type="text" id="username" name="username" placeholder="shadcn"
+      class="flex h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+    <%= kiso(:field, :description) { "This is your public display name." } %>
+  <% end %>
+
+  <%# Input with validation error %>
+  <%= kiso(:field, invalid: true) do %>
+    <%= kiso(:field, :label, for: :password) { "Password" } %>
+    <input type="password" id="password" name="password" value="abc"
+      class="flex h-9 w-full rounded-md border border-error bg-transparent px-3 py-1 text-sm shadow-xs focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-error"
+      aria-invalid="true">
+    <%= kiso(:field, :error, errors: ["Must be at least 8 characters", "Must contain a number"]) %>
+  <% end %>
+</div>

--- a/test/components/previews/kiso/field_preview/radio.html.erb
+++ b/test/components/previews/kiso/field_preview/radio.html.erb
@@ -1,0 +1,33 @@
+<div class="max-w-sm">
+  <%= kiso(:field_set) do %>
+    <%= kiso(:field_set, :legend, variant: :label) { "Subscription Plan" } %>
+    <%= kiso(:field, :description) { "Choose the plan that works best for you." } %>
+
+    <%= kiso(:field, orientation: :horizontal) do %>
+      <input type="radio" id="plan_free" name="plan" value="free" role="radio"
+        class="size-4 accent-primary" checked>
+      <%= kiso(:field, :content) do %>
+        <%= kiso(:field, :label, for: :plan_free) { "Free" } %>
+        <%= kiso(:field, :description) { "Up to 3 projects. Basic features." } %>
+      <% end %>
+    <% end %>
+
+    <%= kiso(:field, orientation: :horizontal) do %>
+      <input type="radio" id="plan_pro" name="plan" value="pro" role="radio"
+        class="size-4 accent-primary">
+      <%= kiso(:field, :content) do %>
+        <%= kiso(:field, :label, for: :plan_pro) { "Pro" } %>
+        <%= kiso(:field, :description) { "Unlimited projects. Priority support." } %>
+      <% end %>
+    <% end %>
+
+    <%= kiso(:field, orientation: :horizontal) do %>
+      <input type="radio" id="plan_enterprise" name="plan" value="enterprise" role="radio"
+        class="size-4 accent-primary">
+      <%= kiso(:field, :content) do %>
+        <%= kiso(:field, :label, for: :plan_enterprise) { "Enterprise" } %>
+        <%= kiso(:field, :description) { "Custom solutions. Dedicated account manager." } %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/test/components/previews/kiso/field_preview/responsive.html.erb
+++ b/test/components/previews/kiso/field_preview/responsive.html.erb
@@ -1,0 +1,32 @@
+<div class="max-w-2xl">
+  <%= kiso(:field_set) do %>
+    <%= kiso(:field_set, :legend) { "Profile" } %>
+    <%= kiso(:field, :description) { "This information will be displayed on your public profile." } %>
+
+    <%= kiso(:field_group) do %>
+      <%= kiso(:field, orientation: :responsive) do %>
+        <%= kiso(:field, :label, for: :resp_name) { "Full name" } %>
+        <input type="text" id="resp_name" name="name" placeholder="Evil Rabbit"
+          class="flex h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+      <% end %>
+
+      <%= kiso(:field, orientation: :responsive) do %>
+        <%= kiso(:field, :label, for: :resp_email) { "Email" } %>
+        <%= kiso(:field, :content) do %>
+          <input type="email" id="resp_email" name="email" placeholder="evil@rabbit.com"
+            class="flex h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+          <%= kiso(:field, :description) { "This will be visible to other members." } %>
+        <% end %>
+      <% end %>
+
+      <%= kiso(:field, orientation: :responsive) do %>
+        <%= kiso(:field, :label, for: :resp_bio) { "Bio" } %>
+        <%= kiso(:field, :content) do %>
+          <textarea id="resp_bio" name="bio" rows="3" placeholder="Tell us about yourself..."
+            class="flex w-full rounded-md border bg-transparent px-3 py-2 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"></textarea>
+          <%= kiso(:field, :description) { "You can use markdown for formatting." } %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/test/components/previews/kiso/field_preview/select.html.erb
+++ b/test/components/previews/kiso/field_preview/select.html.erb
@@ -1,0 +1,14 @@
+<div class="max-w-sm">
+  <%= kiso(:field) do %>
+    <%= kiso(:field, :label, for: :department) { "Department" } %>
+    <select id="department" name="department"
+      class="flex h-9 w-full appearance-none rounded-md border bg-transparent px-3 py-1 text-sm shadow-xs focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+      <option value="" disabled selected>Select a department</option>
+      <option value="engineering">Engineering</option>
+      <option value="design">Design</option>
+      <option value="marketing">Marketing</option>
+      <option value="sales">Sales</option>
+    </select>
+    <%= kiso(:field, :description) { "This determines your team assignment and access level." } %>
+  <% end %>
+</div>

--- a/test/components/previews/kiso/field_preview/switch.html.erb
+++ b/test/components/previews/kiso/field_preview/switch.html.erb
@@ -1,0 +1,22 @@
+<div class="max-w-sm space-y-6">
+  <%# Simple switch %>
+  <%= kiso(:field, orientation: :horizontal) do %>
+    <label class="relative inline-flex h-5 w-9 cursor-pointer items-center rounded-full bg-muted transition-colors has-[:checked]:bg-primary">
+      <input type="checkbox" id="mfa" name="mfa" class="peer sr-only" role="switch">
+      <span class="pointer-events-none block size-4 translate-x-0.5 rounded-full bg-background shadow-sm transition-transform peer-checked:translate-x-[18px]"></span>
+    </label>
+    <%= kiso(:field, :content) do %>
+      <%= kiso(:field, :label, for: :mfa) { "Multi-factor authentication" } %>
+      <%= kiso(:field, :description) { "Add an extra layer of security to your account." } %>
+    <% end %>
+  <% end %>
+
+  <%# Switch with just label %>
+  <%= kiso(:field, orientation: :horizontal) do %>
+    <label class="relative inline-flex h-5 w-9 cursor-pointer items-center rounded-full bg-muted transition-colors has-[:checked]:bg-primary">
+      <input type="checkbox" id="notifications" name="notifications" class="peer sr-only" role="switch" checked>
+      <span class="pointer-events-none block size-4 translate-x-0.5 rounded-full bg-background shadow-sm transition-transform peer-checked:translate-x-[18px]"></span>
+    </label>
+    <%= kiso(:field, :label, for: :notifications) { "Enable notifications" } %>
+  <% end %>
+</div>

--- a/test/components/previews/kiso/field_preview/textarea.html.erb
+++ b/test/components/previews/kiso/field_preview/textarea.html.erb
@@ -1,0 +1,8 @@
+<div class="max-w-sm">
+  <%= kiso(:field) do %>
+    <%= kiso(:field, :label, for: :feedback) { "Feedback" } %>
+    <textarea id="feedback" name="feedback" placeholder="Tell us what you think..." rows="4"
+      class="flex w-full rounded-md border bg-transparent px-3 py-2 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"></textarea>
+    <%= kiso(:field, :description) { "Your feedback helps us improve. We read every message." } %>
+  <% end %>
+</div>


### PR DESCRIPTION
## Summary

- Add **Field** component family — composable form wrappers for labels, controls, descriptions, and errors
- Add **Label** component (#30) as prerequisite
- 10 sub-components matching shadcn's `field.tsx`: Field, FieldContent, FieldLabel, FieldTitle, FieldDescription, FieldError, FieldSeparator, FieldGroup, FieldSet, FieldLegend
- 3 orientation variants: vertical (default), horizontal, responsive (container query)
- FieldError conditionally renders with `errors:` array prop (Rails model errors) or block content
- 10 Lookbook demos matching [shadcn docs](https://ui.shadcn.com/docs/components/radix/field): input, textarea, select, fieldset, checkbox, radio, switch, choice card, field group, responsive

## Files

**Theme modules:**
- `lib/kiso/themes/label.rb`
- `lib/kiso/themes/field.rb` — Field, FieldContent, FieldLabel, FieldTitle, FieldDescription, FieldError, FieldSeparator, FieldSeparatorText
- `lib/kiso/themes/field_group.rb`
- `lib/kiso/themes/field_set.rb` — FieldSet, FieldLegend

**ERB partials:** 11 partials across `_label`, `_field`, `field/`, `_field_group`, `_field_set`, `field_set/`

**Lookbook:** 10 preview scenarios  
**Docs:** `docs/src/components/field.md`  
**Skills:** Updated `components.md` with Forms section

## Test plan

- [x] `bundle exec standardrb --fix` passes
- [x] `bundle exec rake test` passes
- [x] All 10 Lookbook previews render (200)
- [x] FieldError conditional rendering verified (empty errors = no output)
- [x] Multiple errors render as bulleted list
- [ ] Visual review in Lookbook at :4001
- [ ] Dark mode toggle works