### PR TITLE
feat: Checkbox component (#37)

### DIFF
--- a/.claude/skills/contributing/SKILL.md
+++ b/.claude/skills/contributing/SKILL.md
@@ -194,7 +194,7 @@ Progress:
 - [ ] 9. Add CSS file if needed (transitions/animations only)
 - [ ] 10. Update skills/kiso/references/components.md
 - [ ] 11. Write/update project/components/[NAME].md vision doc
-- [ ] 12. Create docs page (see "Documentation page" below)
+- [ ] 12. Create docs page AND add to docs/src/_data/navigation.yml (see "Documentation page" below)
 - [ ] 13. Run: bundle exec standardrb --fix
 - [ ] 14. Rebuild Tailwind: cd test/dummy && bin/rails tailwindcss:build
 - [ ] 15. Verify in Lookbook: http://localhost:4001/lookbook

--- a/app/assets/tailwind/kiso/checkbox.css
+++ b/app/assets/tailwind/kiso/checkbox.css
@@ -1,0 +1,18 @@
+/* Checkbox indicator — CSS ::after for the checkmark since native <input>
+   can't contain child elements. Uses mask-image with the Lucide Check icon. */
+
+[data-component="checkbox"] {
+  display: grid;
+  place-content: center;
+}
+
+[data-component="checkbox"]:checked::after {
+  content: '';
+  width: 0.875em;
+  height: 0.875em;
+  background-color: currentColor;
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M20 6 9 17l-5-5'/%3E%3C/svg%3E");
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  mask-position: center;
+}

--- a/app/assets/tailwind/kiso/engine.css
+++ b/app/assets/tailwind/kiso/engine.css
@@ -3,6 +3,8 @@
    that are awkward to express in ERB. Most styling lives in Ruby theme modules
    (lib/kiso/themes/) as computed Tailwind classes. */
 
+@import "./checkbox.css";
+
 /* Scan Kiso's own files so host apps don't need to know the gem's internals. */
 @source "../../views";
 @source "../../helpers";

--- a/app/views/kiso/components/_checkbox.html.erb
+++ b/app/views/kiso/components/_checkbox.html.erb
@@ -1,0 +1,7 @@
+<%# locals: (color: :primary, checked: false, css_classes: "", **component_options) %>
+<% component_options[:type] = :checkbox
+   component_options[:checked] = true if checked %>
+<%= tag.input(
+    class: Kiso::Themes::Checkbox.render(color: color, class: css_classes),
+    data: kiso_prepare_options(component_options, component: :checkbox),
+    **component_options) %>

--- a/docs/src/_data/navigation.yml
+++ b/docs/src/_data/navigation.yml
@@ -29,6 +29,8 @@ docs:
 
   - heading: Forms
     items:
+      - title: Checkbox
+        href: /components/checkbox
       - title: Field
         href: /components/field
       - title: Input

--- a/docs/src/components/checkbox.md
+++ b/docs/src/components/checkbox.md
@@ -1,0 +1,112 @@
+---
+title: Checkbox
+layout: docs
+description: A toggle control for boolean choices in forms.
+category: Form
+source: lib/kiso/themes/checkbox.rb
+---
+
+## Quick Start
+
+```erb
+<%%= kiso(:checkbox) %>
+```
+
+<%= render "component_preview", component: "kiso/checkbox", scenario: "playground", height: "300px" %>
+
+## Locals
+
+| Local | Type | Default |
+|-------|------|---------|
+| `color:` | `:primary` \| `:secondary` \| `:success` \| `:info` \| `:warning` \| `:error` \| `:neutral` | `:primary` |
+| `checked:` | `Boolean` | `false` |
+| `css_classes:` | `String` | `""` |
+| `**component_options` | `Hash` | `{}` |
+
+All standard HTML input attributes (`name:`, `id:`, `value:`, `disabled:`,
+`required:`, etc.) pass through via `**component_options`.
+
+## Usage
+
+### Color
+
+The color applies to the checked state — background fill, ring, and checkmark.
+
+```erb
+<%%= kiso(:checkbox, color: :primary, checked: true) %>
+<%%= kiso(:checkbox, color: :success, checked: true) %>
+<%%= kiso(:checkbox, color: :error, checked: true) %>
+```
+
+### With Field
+
+Pair with Field for label, description, and validation support.
+
+```erb
+<%%= kiso(:field, orientation: :horizontal) do %>
+  <%%= kiso(:checkbox, id: :terms, name: :terms, value: "1") %>
+  <%%= kiso(:field, :content) do %>
+    <%%= kiso(:field, :label, for: :terms) { "Accept terms and conditions" } %>
+    <%%= kiso(:field, :description) { "You agree to our Terms of Service and Privacy Policy." } %>
+  <%% end %>
+<%% end %>
+```
+
+### Disabled
+
+```erb
+<%%= kiso(:checkbox, disabled: true) %>
+<%%= kiso(:checkbox, checked: true, disabled: true) %>
+```
+
+### With Rails Form Helpers
+
+Use the theme module directly with Rails form builders:
+
+```erb
+<%%= f.check_box :agree,
+    class: Kiso::Themes::Checkbox.render(color: :primary) %>
+```
+
+## Theme
+
+```ruby
+# lib/kiso/themes/checkbox.rb
+Kiso::Themes::Checkbox = ClassVariants.build(
+  base: "appearance-none size-4 shrink-0 rounded-[4px]
+         ring ring-inset ring-accented shadow-xs
+         transition-shadow outline-none
+         disabled:cursor-not-allowed disabled:opacity-50
+         focus-visible:ring-[3px]
+         aria-invalid:ring-error/30 aria-invalid:ring-2",
+  variants: {
+    color: { primary: "", secondary: "", ... }
+  },
+  compound_variants: [
+    { color: :primary, class: "checked:bg-primary checked:ring-primary
+       checked:text-primary-foreground focus-visible:ring-primary/50" },
+    ...
+  ],
+  defaults: { color: :primary }
+)
+```
+
+The checkmark indicator uses a CSS `::after` pseudo-element with a mask-image
+SVG (Lucide Check icon). The `currentColor` inherits from
+`checked:text-{color}-foreground`.
+
+## Accessibility
+
+| Attribute | Value |
+|-----------|-------|
+| `data-component` | `"checkbox"` |
+| `type` | `"checkbox"` |
+| `aria-invalid` | Set when validation fails |
+| `disabled` | Native attribute |
+
+### Keyboard
+
+| Key | Action |
+|-----|--------|
+| `Tab` | Moves focus to/from the checkbox. |
+| `Space` | Toggles checked state. |

--- a/lib/kiso.rb
+++ b/lib/kiso.rb
@@ -18,6 +18,7 @@ require "kiso/themes/field_set"
 require "kiso/themes/input"
 require "kiso/themes/textarea"
 require "kiso/themes/input_group"
+require "kiso/themes/checkbox"
 require "kiso/icons"
 
 module Kiso

--- a/lib/kiso/themes/checkbox.rb
+++ b/lib/kiso/themes/checkbox.rb
@@ -1,0 +1,25 @@
+module Kiso
+  module Themes
+    Checkbox = ClassVariants.build(
+      base: "appearance-none size-4 shrink-0 rounded-[4px] " \
+            "ring ring-inset ring-accented shadow-xs " \
+            "transition-shadow outline-none " \
+            "disabled:cursor-not-allowed disabled:opacity-50 " \
+            "focus-visible:ring-[3px] " \
+            "aria-invalid:ring-error/30 aria-invalid:ring-2",
+      variants: {
+        color: COLORS.index_with { "" }
+      },
+      compound_variants: [
+        {color: :primary, class: "checked:bg-primary checked:ring-primary checked:text-primary-foreground focus-visible:ring-primary/50"},
+        {color: :secondary, class: "checked:bg-secondary checked:ring-secondary checked:text-secondary-foreground focus-visible:ring-secondary/50"},
+        {color: :success, class: "checked:bg-success checked:ring-success checked:text-success-foreground focus-visible:ring-success/50"},
+        {color: :info, class: "checked:bg-info checked:ring-info checked:text-info-foreground focus-visible:ring-info/50"},
+        {color: :warning, class: "checked:bg-warning checked:ring-warning checked:text-warning-foreground focus-visible:ring-warning/50"},
+        {color: :error, class: "checked:bg-error checked:ring-error checked:text-error-foreground focus-visible:ring-error/50"},
+        {color: :neutral, class: "checked:bg-inverted checked:ring-inverted checked:text-inverted-foreground focus-visible:ring-inverted/50"}
+      ],
+      defaults: {color: :primary}
+    )
+  end
+end

--- a/test/components/previews/kiso/checkbox_preview.rb
+++ b/test/components/previews/kiso/checkbox_preview.rb
@@ -1,0 +1,31 @@
+module Kiso
+  # @label Checkbox
+  class CheckboxPreview < Lookbook::Preview
+    # @label Playground
+    # @param color select { choices: [primary, secondary, success, info, warning, error, neutral] }
+    # @param checked toggle
+    # @param disabled toggle
+    def playground(color: :primary, checked: false, disabled: false)
+      render_with_template(locals: {
+        color: color.to_sym,
+        checked: checked,
+        disabled: disabled
+      })
+    end
+
+    # @label Colors
+    def colors
+      render_with_template
+    end
+
+    # @label With Field
+    def with_field
+      render_with_template
+    end
+
+    # @label Disabled
+    def disabled
+      render_with_template
+    end
+  end
+end

--- a/test/components/previews/kiso/checkbox_preview/colors.html.erb
+++ b/test/components/previews/kiso/checkbox_preview/colors.html.erb
@@ -1,0 +1,8 @@
+<div class="flex flex-col gap-4">
+  <% %i[primary secondary success info warning error neutral].each do |color| %>
+    <div class="flex items-center gap-2">
+      <%= kiso(:checkbox, color: color, checked: true, id: color) %>
+      <label for="<%= color %>" class="text-sm text-foreground capitalize"><%= color %></label>
+    </div>
+  <% end %>
+</div>

--- a/test/components/previews/kiso/checkbox_preview/disabled.html.erb
+++ b/test/components/previews/kiso/checkbox_preview/disabled.html.erb
@@ -1,0 +1,11 @@
+<div class="flex flex-col gap-4">
+  <div class="flex items-center gap-2">
+    <%= kiso(:checkbox, disabled: true, id: :disabled_unchecked) %>
+    <label for="disabled_unchecked" class="text-sm text-muted-foreground">Disabled unchecked</label>
+  </div>
+
+  <div class="flex items-center gap-2">
+    <%= kiso(:checkbox, checked: true, disabled: true, id: :disabled_checked) %>
+    <label for="disabled_checked" class="text-sm text-muted-foreground">Disabled checked</label>
+  </div>
+</div>

--- a/test/components/previews/kiso/checkbox_preview/playground.html.erb
+++ b/test/components/previews/kiso/checkbox_preview/playground.html.erb
@@ -1,0 +1,4 @@
+<div class="flex items-center gap-2">
+  <%= kiso(:checkbox, color: color, checked: checked, disabled: disabled, id: :playground) %>
+  <label for="playground" class="text-sm text-foreground">Accept terms and conditions</label>
+</div>

--- a/test/components/previews/kiso/checkbox_preview/with_field.html.erb
+++ b/test/components/previews/kiso/checkbox_preview/with_field.html.erb
@@ -1,0 +1,17 @@
+<div class="max-w-sm flex flex-col gap-4">
+  <%= kiso(:field, orientation: :horizontal) do %>
+    <%= kiso(:checkbox, id: :terms, name: :terms, value: "1") %>
+    <%= kiso(:field, :content) do %>
+      <%= kiso(:field, :label, for: :terms) { "Accept terms and conditions" } %>
+      <%= kiso(:field, :description) { "You agree to our Terms of Service and Privacy Policy." } %>
+    <% end %>
+  <% end %>
+
+  <%= kiso(:field, orientation: :horizontal) do %>
+    <%= kiso(:checkbox, id: :newsletter, name: :newsletter, value: "1", checked: true) %>
+    <%= kiso(:field, :content) do %>
+      <%= kiso(:field, :label, for: :newsletter) { "Subscribe to newsletter" } %>
+      <%= kiso(:field, :description) { "Get notified about new features and updates." } %>
+    <% end %>
+  <% end %>
+</div>

--- a/test/components/previews/kiso/field_preview/checkbox.html.erb
+++ b/test/components/previews/kiso/field_preview/checkbox.html.erb
@@ -4,8 +4,7 @@
     <%= kiso(:field, :description) { "Select the items you want to display on your dashboard." } %>
 
     <%= kiso(:field, orientation: :horizontal) do %>
-      <input type="checkbox" id="cb_recents" name="items[]" value="recents" checked role="checkbox"
-        class="size-4 rounded border accent-primary">
+      <%= kiso(:checkbox, id: :cb_recents, name: "items[]", value: "recents", checked: true) %>
       <%= kiso(:field, :content) do %>
         <%= kiso(:field, :label, for: :cb_recents) { "Recents" } %>
         <%= kiso(:field, :description) { "Shows your most recent activity." } %>
@@ -13,8 +12,7 @@
     <% end %>
 
     <%= kiso(:field, orientation: :horizontal) do %>
-      <input type="checkbox" id="cb_home" name="items[]" value="home" role="checkbox"
-        class="size-4 rounded border accent-primary">
+      <%= kiso(:checkbox, id: :cb_home, name: "items[]", value: "home") %>
       <%= kiso(:field, :content) do %>
         <%= kiso(:field, :label, for: :cb_home) { "Home" } %>
         <%= kiso(:field, :description) { "Shows your home dashboard." } %>
@@ -22,8 +20,7 @@
     <% end %>
 
     <%= kiso(:field, orientation: :horizontal) do %>
-      <input type="checkbox" id="cb_apps" name="items[]" value="apps" role="checkbox"
-        class="size-4 rounded border accent-primary">
+      <%= kiso(:checkbox, id: :cb_apps, name: "items[]", value: "apps") %>
       <%= kiso(:field, :content) do %>
         <%= kiso(:field, :label, for: :cb_apps) { "Applications" } %>
         <%= kiso(:field, :description) { "Shows your installed applications." } %>


### PR DESCRIPTION
## Summary

- Styled native `<input type="checkbox">` with `appearance-none` and Tailwind classes
- Color compound variants for checked state (7 colors: primary, secondary, success, info, warning, error, neutral)
- CSS `::after` checkmark indicator using `mask-image` with Lucide Check icon SVG — first component CSS file (`checkbox.css`)
- Updated Field preview to use `kiso(:checkbox)` instead of plain HTML placeholder
- Docs page + sidebar nav entry
- Contributing skill checklist now explicitly includes adding to `navigation.yml`

## Test plan

- [ ] Lookbook: verify playground, colors, with_field, disabled previews at `:4001`
- [ ] Visual: unchecked ring, checked fill + checkmark, focus ring, disabled opacity
- [ ] Field integration: checkbox + label + description align correctly in Field preview
- [ ] Docs: checkbox page renders at `/components/checkbox` with sidebar nav link
- [ ] Dark mode: checked colors and checkmark visible in both light/dark