### PR TITLE
feat: Breadcrumb component

### DIFF
--- a/app/views/kiso/components/_breadcrumb.html.erb
+++ b/app/views/kiso/components/_breadcrumb.html.erb
@@ -1,0 +1,8 @@
+<%# locals: (css_classes: "", **component_options) %>
+<%= content_tag :nav,
+    class: Kiso::Themes::Breadcrumb.render(class: css_classes),
+    aria: { label: "breadcrumb" },
+    data: kiso_prepare_options(component_options, component: :breadcrumb),
+    **component_options do %>
+  <%= yield %>
+<% end %>

--- a/app/views/kiso/components/breadcrumb/_ellipsis.html.erb
+++ b/app/views/kiso/components/breadcrumb/_ellipsis.html.erb
@@ -1,0 +1,10 @@
+<%# locals: (css_classes: "", **component_options) %>
+<%= content_tag :span,
+    class: Kiso::Themes::BreadcrumbEllipsis.render(class: css_classes),
+    role: "presentation",
+    aria: { hidden: "true" },
+    data: kiso_prepare_options(component_options, component: :breadcrumb, breadcrumb_part: :ellipsis),
+    **component_options do %>
+  <%= kiso_icon "ellipsis", class: "size-4" %>
+  <span class="sr-only">More</span>
+<% end %>

--- a/app/views/kiso/components/breadcrumb/_item.html.erb
+++ b/app/views/kiso/components/breadcrumb/_item.html.erb
@@ -1,0 +1,7 @@
+<%# locals: (css_classes: "", **component_options) %>
+<%= content_tag :li,
+    class: Kiso::Themes::BreadcrumbItem.render(class: css_classes),
+    data: kiso_prepare_options(component_options, component: :breadcrumb, breadcrumb_part: :item),
+    **component_options do %>
+  <%= yield %>
+<% end %>

--- a/app/views/kiso/components/breadcrumb/_link.html.erb
+++ b/app/views/kiso/components/breadcrumb/_link.html.erb
@@ -1,0 +1,7 @@
+<%# locals: (css_classes: "", **component_options) %>
+<%= content_tag :a,
+    class: Kiso::Themes::BreadcrumbLink.render(class: css_classes),
+    data: kiso_prepare_options(component_options, component: :breadcrumb, breadcrumb_part: :link),
+    **component_options do %>
+  <%= yield %>
+<% end %>

--- a/app/views/kiso/components/breadcrumb/_list.html.erb
+++ b/app/views/kiso/components/breadcrumb/_list.html.erb
@@ -1,0 +1,7 @@
+<%# locals: (css_classes: "", **component_options) %>
+<%= content_tag :ol,
+    class: Kiso::Themes::BreadcrumbList.render(class: css_classes),
+    data: kiso_prepare_options(component_options, component: :breadcrumb, breadcrumb_part: :list),
+    **component_options do %>
+  <%= yield %>
+<% end %>

--- a/app/views/kiso/components/breadcrumb/_page.html.erb
+++ b/app/views/kiso/components/breadcrumb/_page.html.erb
@@ -1,0 +1,9 @@
+<%# locals: (css_classes: "", **component_options) %>
+<%= content_tag :span,
+    class: Kiso::Themes::BreadcrumbPage.render(class: css_classes),
+    role: "link",
+    aria: { disabled: "true", current: "page" },
+    data: kiso_prepare_options(component_options, component: :breadcrumb, breadcrumb_part: :page),
+    **component_options do %>
+  <%= yield %>
+<% end %>

--- a/app/views/kiso/components/breadcrumb/_separator.html.erb
+++ b/app/views/kiso/components/breadcrumb/_separator.html.erb
@@ -1,0 +1,13 @@
+<%# locals: (css_classes: "", **component_options) %>
+<%= content_tag :li,
+    class: Kiso::Themes::BreadcrumbSeparator.render(class: css_classes),
+    role: "presentation",
+    aria: { hidden: "true" },
+    data: kiso_prepare_options(component_options, component: :breadcrumb, breadcrumb_part: :separator),
+    **component_options do %>
+  <% if block_given? %>
+    <%= yield %>
+  <% else %>
+    <%= kiso_icon "chevron-right", class: "size-3.5" %>
+  <% end %>
+<% end %>

--- a/docs/src/_data/navigation.yml
+++ b/docs/src/_data/navigation.yml
@@ -31,6 +31,8 @@ docs:
         href: /components/alert
       - title: Badge
         href: /components/badge
+      - title: Breadcrumb
+        href: /components/breadcrumb
       - title: Button
         href: /components/button
       - title: Card

--- a/docs/src/components/breadcrumb.md
+++ b/docs/src/components/breadcrumb.md
@@ -1,0 +1,134 @@
+---
+title: Breadcrumb
+layout: docs
+description: Navigation breadcrumb trail showing the current page's location in the site hierarchy.
+category: Navigation
+source: lib/kiso/themes/breadcrumb.rb
+---
+
+## Quick Start
+
+```erb
+<%%= kui(:breadcrumb) do %>
+  <%%= kui(:breadcrumb, :list) do %>
+    <%%= kui(:breadcrumb, :item) do %>
+      <%%= kui(:breadcrumb, :link, href: "/") { "Home" } %>
+    <%% end %>
+    <%%= kui(:breadcrumb, :separator) %>
+    <%%= kui(:breadcrumb, :item) do %>
+      <%%= kui(:breadcrumb, :link, href: "/components") { "Components" } %>
+    <%% end %>
+    <%%= kui(:breadcrumb, :separator) %>
+    <%%= kui(:breadcrumb, :item) do %>
+      <%%= kui(:breadcrumb, :page) { "Breadcrumb" } %>
+    <%% end %>
+  <%% end %>
+<%% end %>
+```
+
+<%= render "component_preview", component: "kiso/breadcrumb", scenario: "playground" %>
+
+## Locals
+
+All sub-parts accept:
+
+| Local | Type | Default |
+|-------|------|---------|
+| `css_classes:` | String | `""` |
+| `**component_options` | Hash | `{}` |
+
+The `link` sub-part accepts any `<a>` attribute (e.g. `href:`, `target:`).
+
+## Sub-parts
+
+| Part | Usage | HTML | Purpose |
+|------|-------|------|---------|
+| `:list` | `kui(:breadcrumb, :list)` | `<ol>` | Ordered list container |
+| `:item` | `kui(:breadcrumb, :item)` | `<li>` | Segment wrapper |
+| `:link` | `kui(:breadcrumb, :link)` | `<a>` | Clickable ancestor link |
+| `:page` | `kui(:breadcrumb, :page)` | `<span>` | Current page (non-interactive) |
+| `:separator` | `kui(:breadcrumb, :separator)` | `<li>` | Chevron divider (customizable) |
+| `:ellipsis` | `kui(:breadcrumb, :ellipsis)` | `<span>` | Truncation indicator |
+
+## Anatomy
+
+```
+Breadcrumb (nav)
+└── List (ol)
+    ├── Item (li)
+    │   └── Link (a) or Page (span)
+    ├── Separator (li)
+    ├── Item (li)
+    │   └── Ellipsis (span)
+    ├── Separator (li)
+    └── Item (li)
+        └── Page (span)
+```
+
+## Usage
+
+### Default
+
+The most common breadcrumb pattern: ancestor links followed by the current
+page.
+
+```erb
+<%%= kui(:breadcrumb) do %>
+  <%%= kui(:breadcrumb, :list) do %>
+    <%%= kui(:breadcrumb, :item) do %>
+      <%%= kui(:breadcrumb, :link, href: "/") { "Home" } %>
+    <%% end %>
+    <%%= kui(:breadcrumb, :separator) %>
+    <%%= kui(:breadcrumb, :item) do %>
+      <%%= kui(:breadcrumb, :link, href: "/components") { "Components" } %>
+    <%% end %>
+    <%%= kui(:breadcrumb, :separator) %>
+    <%%= kui(:breadcrumb, :item) do %>
+      <%%= kui(:breadcrumb, :page) { "Breadcrumb" } %>
+    <%% end %>
+  <%% end %>
+<%% end %>
+```
+
+### With Ellipsis
+
+Use the ellipsis sub-part to indicate truncated segments in deep hierarchies.
+
+```erb
+<%%= kui(:breadcrumb, :item) do %>
+  <%%= kui(:breadcrumb, :ellipsis) %>
+<%% end %>
+```
+
+<%= render "component_preview", component: "kiso/breadcrumb", scenario: "with_ellipsis" %>
+
+### Custom Separator
+
+Pass a block to the separator sub-part to replace the default chevron icon.
+
+```erb
+<%%= kui(:breadcrumb, :separator) do %>
+  <%%= kiso_icon "slash", class: "size-3.5" %>
+<%% end %>
+```
+
+<%= render "component_preview", component: "kiso/breadcrumb", scenario: "custom_separator" %>
+
+## Theme
+
+```ruby
+Kiso::Themes::Breadcrumb          = ClassVariants.build(base: "")
+Kiso::Themes::BreadcrumbList      = ClassVariants.build(base: "text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm break-words sm:gap-2.5")
+Kiso::Themes::BreadcrumbItem      = ClassVariants.build(base: "inline-flex items-center gap-1.5")
+Kiso::Themes::BreadcrumbLink      = ClassVariants.build(base: "hover:text-foreground transition-colors")
+Kiso::Themes::BreadcrumbPage      = ClassVariants.build(base: "text-foreground font-normal")
+Kiso::Themes::BreadcrumbSeparator = ClassVariants.build(base: "[&>svg]:size-3.5")
+Kiso::Themes::BreadcrumbEllipsis  = ClassVariants.build(base: "flex size-9 items-center justify-center")
+```
+
+## Accessibility
+
+Breadcrumb renders a `<nav>` element with `aria-label="breadcrumb"`. The list
+uses a semantic `<ol>` for proper ordering. Separators have `role="presentation"`
+and `aria-hidden="true"` so screen readers skip them. The current page has
+`aria-current="page"` and `aria-disabled="true"`.

--- a/lib/kiso.rb
+++ b/lib/kiso.rb
@@ -21,6 +21,7 @@ require "kiso/themes/input_group"
 require "kiso/themes/checkbox"
 require "kiso/themes/radio_group"
 require "kiso/themes/switch"
+require "kiso/themes/breadcrumb"
 require "kiso/icons"
 
 module Kiso

--- a/lib/kiso/themes/breadcrumb.rb
+++ b/lib/kiso/themes/breadcrumb.rb
@@ -1,0 +1,39 @@
+module Kiso
+  module Themes
+    # shadcn Breadcrumb: <nav aria-label="breadcrumb">
+    # No classes on the nav element itself.
+    Breadcrumb = ClassVariants.build(
+      base: ""
+    )
+
+    # shadcn BreadcrumbList: text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm break-words sm:gap-2.5
+    BreadcrumbList = ClassVariants.build(
+      base: "text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm break-words sm:gap-2.5"
+    )
+
+    # shadcn BreadcrumbItem: inline-flex items-center gap-1.5
+    BreadcrumbItem = ClassVariants.build(
+      base: "inline-flex items-center gap-1.5"
+    )
+
+    # shadcn BreadcrumbLink: hover:text-foreground transition-colors
+    BreadcrumbLink = ClassVariants.build(
+      base: "hover:text-foreground transition-colors"
+    )
+
+    # shadcn BreadcrumbPage: text-foreground font-normal
+    BreadcrumbPage = ClassVariants.build(
+      base: "text-foreground font-normal"
+    )
+
+    # shadcn BreadcrumbSeparator: [&>svg]:size-3.5
+    BreadcrumbSeparator = ClassVariants.build(
+      base: "[&>svg]:size-3.5"
+    )
+
+    # shadcn BreadcrumbEllipsis: flex size-9 items-center justify-center
+    BreadcrumbEllipsis = ClassVariants.build(
+      base: "flex size-9 items-center justify-center"
+    )
+  end
+end

--- a/skills/kiso/references/components.md
+++ b/skills/kiso/references/components.md
@@ -31,6 +31,12 @@ All colored components use **identical compound variant formulas** — see `proj
 | `radio_group` | `color` (7 colors). Sub-part: item | [radio_group.md](components/radio_group.md) |
 | `switch` | `color` (7 colors), `size` (sm/md), `checked` | [switch.md](components/switch.md) |
 
+## Navigation
+
+| Component | Key locals | Reference |
+|---|---|---|
+| `breadcrumb` | 7 sub-parts: list, item, link, page, separator, ellipsis | [breadcrumb.md](components/breadcrumb.md) |
+
 ## Element
 
 | Component | Key locals | Reference |

--- a/skills/kiso/references/components/breadcrumb.md
+++ b/skills/kiso/references/components/breadcrumb.md
@@ -1,0 +1,45 @@
+# Breadcrumb
+
+Navigation breadcrumb trail showing the current page's location in the site hierarchy. Pure HTML/CSS, no JavaScript.
+
+**Locals:** `css_classes:`, `**component_options`
+
+**Sub-parts:** `kui(:breadcrumb, :list)`, `kui(:breadcrumb, :item)`, `kui(:breadcrumb, :link)`, `kui(:breadcrumb, :page)`, `kui(:breadcrumb, :separator)`, `kui(:breadcrumb, :ellipsis)`
+
+**Defaults:** None (no variant axes).
+
+```erb
+<%= kui(:breadcrumb) do %>
+  <%= kui(:breadcrumb, :list) do %>
+    <%= kui(:breadcrumb, :item) do %>
+      <%= kui(:breadcrumb, :link, href: "/") { "Home" } %>
+    <% end %>
+    <%= kui(:breadcrumb, :separator) %>
+    <%= kui(:breadcrumb, :item) do %>
+      <%= kui(:breadcrumb, :link, href: "/components") { "Components" } %>
+    <% end %>
+    <%= kui(:breadcrumb, :separator) %>
+    <%= kui(:breadcrumb, :item) do %>
+      <%= kui(:breadcrumb, :page) { "Breadcrumb" } %>
+    <% end %>
+  <% end %>
+<% end %>
+```
+
+**Ellipsis** for truncated segments:
+
+```erb
+<%= kui(:breadcrumb, :item) do %>
+  <%= kui(:breadcrumb, :ellipsis) %>
+<% end %>
+```
+
+**Custom separator** (pass a block):
+
+```erb
+<%= kui(:breadcrumb, :separator) do %>
+  <%= kiso_icon "slash", class: "size-3.5" %>
+<% end %>
+```
+
+**Theme modules:** `Kiso::Themes::Breadcrumb`, `BreadcrumbList`, `BreadcrumbItem`, `BreadcrumbLink`, `BreadcrumbPage`, `BreadcrumbSeparator`, `BreadcrumbEllipsis` (`lib/kiso/themes/breadcrumb.rb`)

--- a/test/components/previews/kiso/breadcrumb_preview.rb
+++ b/test/components/previews/kiso/breadcrumb_preview.rb
@@ -1,0 +1,24 @@
+module Kiso
+  # @label Breadcrumb
+  class BreadcrumbPreview < Lookbook::Preview
+    # @label Playground
+    def playground
+      render_with_template
+    end
+
+    # @label With Ellipsis
+    def with_ellipsis
+      render_with_template
+    end
+
+    # @label Custom Separator
+    def custom_separator
+      render_with_template
+    end
+
+    # @label Link Only
+    def link_only
+      render_with_template
+    end
+  end
+end

--- a/test/components/previews/kiso/breadcrumb_preview/custom_separator.html.erb
+++ b/test/components/previews/kiso/breadcrumb_preview/custom_separator.html.erb
@@ -1,0 +1,21 @@
+<div class="text-foreground">
+  <%= kui(:breadcrumb) do %>
+    <%= kui(:breadcrumb, :list) do %>
+      <%= kui(:breadcrumb, :item) do %>
+        <%= kui(:breadcrumb, :link, href: "#") { "Home" } %>
+      <% end %>
+      <%= kui(:breadcrumb, :separator) do %>
+        <%= kiso_icon "slash", class: "size-3.5" %>
+      <% end %>
+      <%= kui(:breadcrumb, :item) do %>
+        <%= kui(:breadcrumb, :link, href: "#") { "Components" } %>
+      <% end %>
+      <%= kui(:breadcrumb, :separator) do %>
+        <%= kiso_icon "slash", class: "size-3.5" %>
+      <% end %>
+      <%= kui(:breadcrumb, :item) do %>
+        <%= kui(:breadcrumb, :page) { "Breadcrumb" } %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/test/components/previews/kiso/breadcrumb_preview/link_only.html.erb
+++ b/test/components/previews/kiso/breadcrumb_preview/link_only.html.erb
@@ -1,0 +1,17 @@
+<div class="text-foreground">
+  <%= kui(:breadcrumb) do %>
+    <%= kui(:breadcrumb, :list) do %>
+      <%= kui(:breadcrumb, :item) do %>
+        <%= kui(:breadcrumb, :link, href: "#") { "Home" } %>
+      <% end %>
+      <%= kui(:breadcrumb, :separator) %>
+      <%= kui(:breadcrumb, :item) do %>
+        <%= kui(:breadcrumb, :link, href: "#") { "Components" } %>
+      <% end %>
+      <%= kui(:breadcrumb, :separator) %>
+      <%= kui(:breadcrumb, :item) do %>
+        <%= kui(:breadcrumb, :link, href: "#") { "Breadcrumb" } %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/test/components/previews/kiso/breadcrumb_preview/playground.html.erb
+++ b/test/components/previews/kiso/breadcrumb_preview/playground.html.erb
@@ -1,0 +1,17 @@
+<div class="text-foreground">
+  <%= kui(:breadcrumb) do %>
+    <%= kui(:breadcrumb, :list) do %>
+      <%= kui(:breadcrumb, :item) do %>
+        <%= kui(:breadcrumb, :link, href: "#") { "Home" } %>
+      <% end %>
+      <%= kui(:breadcrumb, :separator) %>
+      <%= kui(:breadcrumb, :item) do %>
+        <%= kui(:breadcrumb, :link, href: "#") { "Components" } %>
+      <% end %>
+      <%= kui(:breadcrumb, :separator) %>
+      <%= kui(:breadcrumb, :item) do %>
+        <%= kui(:breadcrumb, :page) { "Breadcrumb" } %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/test/components/previews/kiso/breadcrumb_preview/with_ellipsis.html.erb
+++ b/test/components/previews/kiso/breadcrumb_preview/with_ellipsis.html.erb
@@ -1,0 +1,21 @@
+<div class="text-foreground">
+  <%= kui(:breadcrumb) do %>
+    <%= kui(:breadcrumb, :list) do %>
+      <%= kui(:breadcrumb, :item) do %>
+        <%= kui(:breadcrumb, :link, href: "#") { "Home" } %>
+      <% end %>
+      <%= kui(:breadcrumb, :separator) %>
+      <%= kui(:breadcrumb, :item) do %>
+        <%= kui(:breadcrumb, :ellipsis) %>
+      <% end %>
+      <%= kui(:breadcrumb, :separator) %>
+      <%= kui(:breadcrumb, :item) do %>
+        <%= kui(:breadcrumb, :link, href: "#") { "Components" } %>
+      <% end %>
+      <%= kui(:breadcrumb, :separator) %>
+      <%= kui(:breadcrumb, :item) do %>
+        <%= kui(:breadcrumb, :page) { "Breadcrumb" } %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>


### PR DESCRIPTION
## Summary
- Breadcrumb navigation component with 7 sub-parts matching shadcn exactly
- Theme module with all shadcn classes ported 1:1
- 7 ERB partials: nav, list, item, link, page, separator, ellipsis
- Separator defaults to chevron-right icon, customizable via yield block
- Ellipsis sub-part with sr-only "More" text
- Full accessibility: aria-label, aria-current, aria-hidden, role attributes
- 4 Lookbook previews: playground, with ellipsis, custom separator, link only
- Docs page, navigation entry, skills reference

Closes #47

## Test plan
- [x] All Lookbook previews render (200)
- [x] standardrb passes
- [x] rake test passes
- [ ] Visual review in Lookbook