### PR TITLE
Adopt data-slot convention from shadcn v4

### DIFF
--- a/.claude/agents/component-builder.md
+++ b/.claude/agents/component-builder.md
@@ -66,7 +66,7 @@ Main partial: `app/views/kiso/components/_{name}.html.erb`
 <%# locals: (variant: :outline, css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::ComponentName.render(variant: variant, class: css_classes),
-    data: kiso_prepare_options(component_options, component: :component_name),
+    data: kiso_prepare_options(component_options, slot: "component-name"),
     **component_options do %>
   <%= yield %>
 <% end %>
@@ -78,7 +78,7 @@ Sub-part partial: `app/views/kiso/components/{name}/_{part}.html.erb`
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::ComponentNamePart.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :component_name, component_name_part: :part),
+    data: kiso_prepare_options(component_options, slot: "component-name-part"),
     **component_options do %>
   <%= yield %>
 <% end %>
@@ -88,7 +88,7 @@ Rules:
 - `text-foreground` on every container component root
 - Strict locals on every partial
 - `css_classes: ""` and `**component_options` on every partial
-- Use `kiso_prepare_options()` for data attributes
+- Use `kiso_prepare_options(slot: "kebab-case-name")` for data-slot identity
 - Match the HTML element shadcn uses (`<div>`, `<label>`, `<fieldset>`, etc.)
 - **Never use `block_given?` in ERB partials** — it's always `true` due to
   Rails internals. For default content with optional block override, use:

--- a/.claude/agents/component-reviewer.md
+++ b/.claude/agents/component-reviewer.md
@@ -68,7 +68,7 @@ component/sub-part:
   - `bg-card`, `bg-destructive`, etc. → Kiso semantic tokens
   - `text-destructive` → `text-error`
   - `dark:` prefixes → removed (Kiso uses CSS variable swapping)
-  - `data-slot` selectors → `data-component` / `data-{name}-part` selectors
+  - `data-slot` naming should match shadcn (kebab-case)
 
 **Common mistakes:** Dropping classes, adding classes that shadcn doesn't have,
 using arbitrary values, changing spacing.
@@ -98,12 +98,13 @@ Check the theme module's `base:` string for `text-foreground`.
 **Exceptions:** Sub-parts that inherit color from parent (like AlertTitle
 inside Alert). Components inside colored parents that use `opacity-90`.
 
-#### Check 6: Data attributes
+#### Check 6: Data slot identity
 
 Verify:
-- Root component: `data: kiso_prepare_options(component_options, component: :name)`
-- Sub-parts: `data: kiso_prepare_options(component_options, component: :name, name_part: :part)`
-- No raw `data: { component: :name }` — always use `kiso_prepare_options`
+- Root component: `data: kiso_prepare_options(component_options, slot: "name")`
+- Sub-parts: `data: kiso_prepare_options(component_options, slot: "name-part")`
+- All slot values use kebab-case (e.g., `"toggle-group"`, not `"toggle_group"`)
+- No raw `data: { slot: ... }` — always use `kiso_prepare_options`
 
 #### Check 7: All deliverables present
 

--- a/.claude/skills/contributing/SKILL.md
+++ b/.claude/skills/contributing/SKILL.md
@@ -111,7 +111,7 @@ app/
 ├── assets/
 │   ├── stylesheets/kiso/   # Component CSS (transitions/pseudo-states only)
 │   └── tailwind/kiso/  # engine.css — shipped with gem (fonts + all color tokens)
-├── helpers/kiso/           # component_tag, kui() helpers
+├── helpers/kiso/           # kui(), kiso_prepare_options() helpers
 └── javascript/controllers/kiso/  # Stimulus controllers (namespaced)
 test/
 ├── components/previews/kiso/  # Lookbook previews + templates
@@ -359,7 +359,7 @@ For composed usage via `kui(:component, :part)`:
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::AlertTitle.render(class: css_classes),
-    data: { component: :alert, alert_part: :title },
+    data: kiso_prepare_options(component_options, slot: "alert-title"),
     **component_options do %>
   <%= yield %>
 <% end %>
@@ -384,10 +384,10 @@ For composed usage via `kui(:component, :part)`:
 | Icon sizing | `size-4` standard, `size-3` compact, `size-5` larger. No arbitrary values. |
 | Container padding | `p-6` large (Card, Dialog), `p-4` medium (Sheet, Popover), `p-2` compact. |
 | No arbitrary values | Never use `text-[8px]`, `h-[1.15rem]`, etc. Use standard Tailwind classes only. |
-| Sub-part naming | `kui(:alert, :title)` — **never** `kui(:alert_title)`. Files live in `alert/_title.html.erb`. Data attrs: `component: :alert, alert_part: :title`. |
+| Sub-part naming | `kui(:alert, :title)` — **never** `kui(:alert_title)`. Files live in `alert/_title.html.erb`. Slot: `data-slot="alert-title"`. |
 | No `block_given?` in ERB | Rails makes `block_given?` always true in partials. Use `capture { yield }.presence` for default-with-override. |
 | Strict locals | Every partial: `<%# locals: (color: :primary, ...) %>` |
-| Data attributes | `data-component="alert"` for identity — NOT for CSS selectors. |
+| Data slot | `data-slot="alert"` for identity (shadcn v4 convention). Kebab-case. Can be used as CSS selectors (`has-[[data-slot=...]]`). |
 | `css_classes:` override | Single override point, merged via tailwind_merge. |
 | Lookbook previews | Playground first, then Colors, Variants, feature galleries. |
 | Lookbook dark mode | Preview wrapper `div`s must include `text-foreground` so text/icons are visible in dark mode. Lookbook doesn't set a base text color on the preview iframe. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Core engine with `kui()` component helper and `component_tag` builder
+- Core engine with `kui()` component helper and `kiso_prepare_options` builder
 - `class_variants` + `tailwind_merge` integration for variant definitions
 - Theme CSS with 7 palettes, surface tokens, and dark mode
 - Badge component (color × variant × size, pill shape, SVG handling)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,8 +83,12 @@ Consistency is more important than any individual improvement.
   Nuxt UI provides the paint.
 - **`css_classes:` override** — single override point, merged via
   tailwind_merge. Conflicting classes are resolved automatically.
-- **Data attributes for identity, not styling** — `data-component="badge"`
-  for testing, Stimulus, debugging. NOT for CSS selectors.
+- **`data-slot` for component identity (shadcn v4 convention)** — every
+  component and sub-part gets `data-slot="name"` in kebab-case. Root:
+  `data-slot="card"`, sub-parts: `data-slot="card-header"`. Used for CSS
+  targeting (`has-[[data-slot=...]]`), testing, and Stimulus. Stimulus
+  controllers (`data-controller`, `data-action`, `data-*-target`) are
+  added separately when behavior is needed.
 - **Native HTML5 first** — `<dialog>`, `[popover]`, `<details>`, `<progress>`
   before reaching for Stimulus.
 - **Props for common patterns, yield for override** — if 90% of usages look
@@ -108,8 +112,7 @@ Consistency is more important than any individual improvement.
   Small partials, flexibly combined.
 - **Sub-part naming** — sub-parts always use `kui(:component, :part)`, never
   `kui(:component_part)`. Files live in `component/_part.html.erb`. Data
-  attributes follow `component: :alert, alert_part: :title` — not
-  `component: :alert_title`.
+  slots use kebab-case: `data-slot="alert-title"`, `data-slot="card-header"`.
 - **Strict locals on every partial** — `<%# locals: (color: :primary) %>`
 
 ## Component Pattern
@@ -129,7 +132,7 @@ Kiso::Themes::Badge = ClassVariants.build(
 <%# locals: (color: :primary, variant: :soft, size: :md, css_classes: "", **component_options) %>
 <%= content_tag :span,
     class: Kiso::Themes::Badge.render(color: color, variant: variant, size: size, class: css_classes),
-    data: { component: :badge },
+    data: kiso_prepare_options(component_options, slot: "badge"),
     **component_options do %>
   <%= yield %>
 <% end %>
@@ -141,7 +144,7 @@ Kiso::Themes::Badge = ClassVariants.build(
 lib/kiso/themes/           Ruby theme modules (ClassVariants definitions)
 app/views/kiso/components/ ERB partials (rendered via kui() helper)
 app/assets/stylesheets/    Component CSS (thin — transitions/pseudo-states only)
-app/helpers/kiso/          component_tag, kui() helpers
+app/helpers/kiso/          kui(), kiso_prepare_options() helpers
 test/components/previews/  Lookbook preview classes + templates
 test/dummy/                Development Rails app (bin/dev → port 4001)
 skills/kiso/               AI skill (component reference, theming guide)

--- a/PLAN.md
+++ b/PLAN.md
@@ -21,7 +21,7 @@ Reference: `vendor/maquina_components/` (local checkout)
 
 - [x] Gem skeleton (Rails engine, isolate_namespace, engine_name)
 - [x] test/dummy/ app (Lookbook, Tailwind v4, Propshaft, port 4001)
-- [x] Core helpers: `component_tag()`, `kui()` in ComponentHelper
+- [x] Core helpers: `kui()`, `kiso_prepare_options()` in ComponentHelper
 - [x] class_variants + tailwind_merge integration
 - [x] Theme CSS: 7 semantic palettes + surface tokens + dark mode
 - [x] Badge component (color × variant × size, compound variants)
@@ -93,10 +93,10 @@ below exists in maquina_components.
 | Stats | simple | done | Stats card + stats grid for dashboards |
 | Table | simple | done | 7 sub-parts: header, body, footer, row, head, cell, caption |
 
-**Batch 2 — Form inputs (CSS-only via data attributes in maquina):**
+**Batch 2 — Form inputs:**
 
-Maquina uses `data-component="input"` etc. for CSS-only form styling.
-Kiso will use `kui(:input)` partials with class_variants themes.
+Kiso uses `kui(:input)` partials with class_variants themes and
+`data-slot` identity attributes (shadcn v4 convention).
 
 | Component | Type | Maquina Notes |
 |-----------|------|---------------|

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) to help out.
 ```
 app/views/kiso/components/   ERB partials
 lib/kiso/themes/             Theme files (class_variants)
-app/helpers/kiso/            component_tag, kui() helpers
+app/helpers/kiso/            kui(), kiso_prepare_options() helpers
 app/assets/stylesheets/kiso/ CSS (only transitions and pseudo-states)
 test/components/previews/    Lookbook previews
 test/dummy/                  Dev Rails app

--- a/VISION.md
+++ b/VISION.md
@@ -20,7 +20,7 @@ simplicity**. Every component works with Turbo out of the box.
 
 ```
 1. ERB Partials          <%= kui(:card) { ... } %>
-2. CSS (data-attributes)  [data-component="card"] { ... }
+2. CSS (data-slot)       [data-slot="card"] { ... }
 3. Stimulus Controllers   data-controller="kiso--combobox" (only when needed)
 ```
 
@@ -28,9 +28,10 @@ simplicity**. Every component works with Turbo out of the box.
 `yield` and sub-part partials (Card > Header > Title). No Ruby class overhead,
 no ViewComponent dependency.
 
-**CSS** targets `data-component` and `data-variant` attributes using
-`@apply` for Tailwind utilities and CSS custom properties for theming. Every
-component is a standalone CSS file, imported into a master `engine.css`.
+**CSS** targets `data-slot` attributes (shadcn v4 convention) for component
+identity and contextual styling (`has-[[data-slot=...]]`). Theme modules
+define Tailwind utility classes in Ruby; CSS files are thin (transitions,
+pseudo-states only).
 
 **Stimulus controllers** are added progressively. Native HTML5 first:
 `<dialog>`, Popover API, `<details>/<summary>`, `<input type="range">`. Stimulus
@@ -199,13 +200,15 @@ defaults, and the host app's Iconify Tailwind plugin.
 
 ### Component API Pattern
 
-Every component follows the same conventions, powered by a `component_tag`
-helper that handles all the data-attribute wiring:
+Every component follows the same conventions, using `kiso_prepare_options`
+to set `data-slot` (shadcn v4 convention) for component identity:
 
 ```erb
 <%# kiso/components/_badge.html.erb %>
-<%# locals: (variant: :default, size: :md, css_classes: "", **component_options) %>
-<%= component_tag :span, :badge, variant:, size:, class: css_classes,
+<%# locals: (color: :primary, variant: :soft, size: :md, css_classes: "", **component_options) %>
+<%= content_tag :span,
+    class: Kiso::Themes::Badge.render(color: color, variant: variant, size: size, class: css_classes),
+    data: kiso_prepare_options(component_options, slot: "badge"),
     **component_options do %>
   <%= yield %>
 <% end %>
@@ -214,40 +217,37 @@ helper that handles all the data-attribute wiring:
 This produces:
 
 ```html
-<span data-component="badge" data-variant="default" data-size="md">Active</span>
+<span data-slot="badge" class="...">Active</span>
 ```
 
-The `component_tag` helper (in `Kiso::ComponentHelper`):
-- Wraps `content_tag` with automatic data-attribute merging
-- Sets `data-component`, `data-variant`, `data-size` from keyword args
-- Merges any caller-provided `data:` hash (so apps can add their own data
-  attributes without clobbering component ones)
-- Compacts nil values — omit `size:` and no `data-size` appears
+The `kiso_prepare_options` helper (in `Kiso::ComponentHelper`):
+- Sets `data-slot` for component identity (kebab-case, matching shadcn v4)
+- Guards against accidental `class:` usage (must use `css_classes:`)
+- Merges any caller-provided `data:` hash from `component_options`
+- Accepts extra `**data_attrs` for Stimulus bindings, state, etc.
 
-**Sub-parts** use the `part:` parameter:
+**Sub-parts** use the same `slot:` parameter with a combined name:
 
 ```erb
 <%# kiso/components/card/_header.html.erb %>
 <%# locals: (css_classes: "", **component_options) %>
-<%= component_tag :div, :card, part: :header, class: css_classes,
+<%= content_tag :div,
+    class: Kiso::Themes::CardHeader.render(class: css_classes),
+    data: kiso_prepare_options(component_options, slot: "card-header"),
     **component_options do %>
   <%= yield %>
 <% end %>
 ```
 
-Produces `<div data-card-part="header">` (no `data-component` on sub-parts).
+Produces `<div data-slot="card-header">`.
 
 **API summary:**
 
-| Argument | Purpose | Output |
+| `slot:` value | Purpose | Output |
 |---|---|---|
-| `:span` | HTML element | `<span ...>` |
-| `:badge` | Component name | `data-component="badge"` |
-| `variant:` | Visual style | `data-variant="..."` |
-| `size:` | Dimensions | `data-size="..."` |
-| `part:` | Sub-part name | `data-badge-part="..."` |
-| `class:` | Extra Tailwind classes | `class="..."` |
-| `**options` | Passthrough HTML attrs | `id="..."`, `aria-*`, etc. |
+| `"badge"` | Root component | `data-slot="badge"` |
+| `"card-header"` | Sub-part | `data-slot="card-header"` |
+| `"toggle-group"` | Multi-word root | `data-slot="toggle-group"` |
 
 ### Rendering Components
 
@@ -365,7 +365,7 @@ kiso/
         dropdown_menu_helper.rb
         table_helper.rb
         toggle_group_helper.rb
-        component_helper.rb      # component_tag() + kui() render helper
+        component_helper.rb      # kui() + kiso_prepare_options() helpers
     javascript/
       controllers/
         kiso/                    # Namespaced under kiso--
@@ -688,8 +688,9 @@ real usage.
 1. **Native first.** Use `<dialog>`, `[popover]`, `<details>`, `<progress>`
    before reaching for JavaScript. Progressive enhancement, not reimplementation.
 
-2. **Data attributes are the API.** `data-component`, `data-variant`,
-   `data-size`, `data-*-part`. CSS selects on these. No class soup.
+2. **`data-slot` is the identity API.** Every component gets `data-slot`
+   (shadcn v4 convention). CSS targets via `[data-slot=...]` and
+   `has-[[data-slot=...]]`. No class soup.
 
 3. **Composition over configuration.** Card is Header + Title + Content +
    Footer. Not `<Card title="..." footer="...">`. Small pieces, flexibly

--- a/app/helpers/kiso/component_helper.rb
+++ b/app/helpers/kiso/component_helper.rb
@@ -1,29 +1,5 @@
 module Kiso
   module ComponentHelper
-    # Renders a component element with data-attribute API.
-    #
-    #   component_tag(:span, :badge, variant: :primary, size: :md) { "Active" }
-    #   # => <span data-component="badge" data-variant="primary" data-size="md">Active</span>
-    #
-    #   component_tag(:div, :card, part: :header) { ... }
-    #   # => <div data-card-part="header">...</div>
-    #
-    def component_tag(element, component, variant: nil, size: nil, part: nil, **options, &block)
-      data = options.delete(:data) || {}
-
-      if part
-        data[:"#{component}-part"] = part
-      else
-        data[:component] = component
-        data[:variant] = variant if variant
-        data[:size] = size if size
-      end
-
-      options[:data] = data
-
-      content_tag(element, **options, &block)
-    end
-
     # Renders a Kiso component partial.
     #
     #   kui(:badge, variant: :success) { "Active" }
@@ -45,17 +21,19 @@ module Kiso
     end
 
     # Prepares component_options for use with content_tag.
-    # Guards against accidental class: usage and merges data attributes.
+    # Sets data-slot for component identity (shadcn v4 convention)
+    # and guards against accidental class: usage.
     #
-    #   data: kiso_prepare_options(component_options, component: :badge)
-    #   data: kiso_prepare_options(component_options, component: :card, card_part: :header)
+    #   data: kiso_prepare_options(component_options, slot: "badge")
+    #   data: kiso_prepare_options(component_options, slot: "card-header")
+    #   data: kiso_prepare_options(component_options, slot: "toggle", controller: "kiso--toggle")
     #
-    def kiso_prepare_options(component_options, **data_attrs)
+    def kiso_prepare_options(component_options, slot:, **data_attrs)
       if component_options.key?(:class)
         raise ArgumentError, "Use css_classes: instead of class: for Kiso components"
       end
 
-      (component_options.delete(:data) || {}).merge(data_attrs)
+      (component_options.delete(:data) || {}).merge(slot: slot, **data_attrs)
     end
   end
 end

--- a/app/views/kiso/components/_alert.html.erb
+++ b/app/views/kiso/components/_alert.html.erb
@@ -2,7 +2,7 @@
 <%= content_tag :div,
     role: :alert,
     class: Kiso::Themes::Alert.render(color: color, variant: variant, class: css_classes),
-    data: kiso_prepare_options(component_options, component: :alert),
+    data: kiso_prepare_options(component_options, slot: "alert"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/_badge.html.erb
+++ b/app/views/kiso/components/_badge.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (color: :primary, variant: :soft, size: :md, css_classes: "", **component_options) %>
 <%= content_tag :span,
     class: Kiso::Themes::Badge.render(color: color, variant: variant, size: size, class: css_classes),
-    data: kiso_prepare_options(component_options, component: :badge),
+    data: kiso_prepare_options(component_options, slot: "badge"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/_breadcrumb.html.erb
+++ b/app/views/kiso/components/_breadcrumb.html.erb
@@ -2,7 +2,7 @@
 <%= content_tag :nav,
     class: Kiso::Themes::Breadcrumb.render(class: css_classes),
     aria: { label: "breadcrumb" },
-    data: kiso_prepare_options(component_options, component: :breadcrumb),
+    data: kiso_prepare_options(component_options, slot: "breadcrumb"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/_button.html.erb
+++ b/app/views/kiso/components/_button.html.erb
@@ -13,7 +13,7 @@
     class: Kiso::Themes::Button.render(
       color: color, variant: variant, size: size, block: block,
       class: css_classes),
-    data: kiso_prepare_options(component_options, component: :button),
+    data: kiso_prepare_options(component_options, slot: "button"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/_card.html.erb
+++ b/app/views/kiso/components/_card.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (variant: :outline, css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::Card.render(variant: variant, class: css_classes),
-    data: kiso_prepare_options(component_options, component: :card),
+    data: kiso_prepare_options(component_options, slot: "card"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/_checkbox.html.erb
+++ b/app/views/kiso/components/_checkbox.html.erb
@@ -3,5 +3,5 @@
    component_options[:checked] = true if checked %>
 <%= tag.input(
     class: Kiso::Themes::Checkbox.render(color: color, class: css_classes),
-    data: kiso_prepare_options(component_options, component: :checkbox),
+    data: kiso_prepare_options(component_options, slot: "checkbox"),
     **component_options) %>

--- a/app/views/kiso/components/_empty.html.erb
+++ b/app/views/kiso/components/_empty.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::Empty.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :empty),
+    data: kiso_prepare_options(component_options, slot: "empty"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/_field.html.erb
+++ b/app/views/kiso/components/_field.html.erb
@@ -2,7 +2,7 @@
 <%= content_tag :div,
     role: :group,
     class: Kiso::Themes::Field.render(orientation: orientation, class: css_classes),
-    data: kiso_prepare_options(component_options, component: :field).merge(
+    data: kiso_prepare_options(component_options, slot: "field").merge(
       orientation: orientation,
       invalid: (true if invalid),
       disabled: (true if disabled)

--- a/app/views/kiso/components/_field_group.html.erb
+++ b/app/views/kiso/components/_field_group.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::FieldGroup.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :field_group),
+    data: kiso_prepare_options(component_options, slot: "field-group"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/_field_set.html.erb
+++ b/app/views/kiso/components/_field_set.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :fieldset,
     class: Kiso::Themes::FieldSet.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :field_set),
+    data: kiso_prepare_options(component_options, slot: "field-set"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/_input.html.erb
+++ b/app/views/kiso/components/_input.html.erb
@@ -4,5 +4,5 @@
    component_options[:disabled] = true if disabled %>
 <%= tag.input(
     class: Kiso::Themes::Input.render(variant: variant, size: size, class: css_classes),
-    data: kiso_prepare_options(component_options, component: :input),
+    data: kiso_prepare_options(component_options, slot: "input"),
     **component_options) %>

--- a/app/views/kiso/components/_input_group.html.erb
+++ b/app/views/kiso/components/_input_group.html.erb
@@ -2,7 +2,7 @@
 <%= content_tag :div,
     role: :group,
     class: Kiso::Themes::InputGroup.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :input_group),
+    data: kiso_prepare_options(component_options, slot: "input-group"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/_label.html.erb
+++ b/app/views/kiso/components/_label.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= tag.label(
     class: Kiso::Themes::Label.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :label),
+    data: kiso_prepare_options(component_options, slot: "label"),
     **component_options) { yield } %>

--- a/app/views/kiso/components/_pagination.html.erb
+++ b/app/views/kiso/components/_pagination.html.erb
@@ -3,7 +3,7 @@
     role: "navigation",
     aria: {label: "pagination"},
     class: Kiso::Themes::Pagination.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :pagination),
+    data: kiso_prepare_options(component_options, slot: "pagination"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/_radio_group.html.erb
+++ b/app/views/kiso/components/_radio_group.html.erb
@@ -2,7 +2,7 @@
 <% component_options[:role] = :radiogroup %>
 <%= content_tag :div,
     class: Kiso::Themes::RadioGroup.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :radio_group),
+    data: kiso_prepare_options(component_options, slot: "radio-group"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/_separator.html.erb
+++ b/app/views/kiso/components/_separator.html.erb
@@ -3,5 +3,5 @@
     role: (decorative ? "none" : "separator"),
     aria: (decorative ? {} : { orientation: orientation }),
     class: Kiso::Themes::Separator.render(orientation: orientation, class: css_classes),
-    data: kiso_prepare_options(component_options, component: :separator),
+    data: kiso_prepare_options(component_options, slot: "separator"),
     **component_options) %>

--- a/app/views/kiso/components/_stats_card.html.erb
+++ b/app/views/kiso/components/_stats_card.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (variant: :outline, css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::StatsCard.render(variant: variant, class: css_classes),
-    data: kiso_prepare_options(component_options, component: :stats_card),
+    data: kiso_prepare_options(component_options, slot: "stats-card"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/_stats_grid.html.erb
+++ b/app/views/kiso/components/_stats_grid.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (columns: 4, css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::StatsGrid.render(columns: columns, class: css_classes),
-    data: kiso_prepare_options(component_options, component: :stats_grid),
+    data: kiso_prepare_options(component_options, slot: "stats-grid"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/_switch.html.erb
+++ b/app/views/kiso/components/_switch.html.erb
@@ -4,7 +4,7 @@
    component_options[:checked] = true if checked %>
 <%= tag.label(
     class: Kiso::Themes::SwitchTrack.render(color: color, size: size, class: css_classes),
-    data: kiso_prepare_options(component_options, component: :switch)) do %>
+    data: kiso_prepare_options(component_options, slot: "switch")) do %>
   <%= tag.input(class: "peer sr-only", **component_options) %>
   <%= tag.span(class: Kiso::Themes::SwitchThumb.render(size: size)) %>
 <% end %>

--- a/app/views/kiso/components/_table.html.erb
+++ b/app/views/kiso/components/_table.html.erb
@@ -2,7 +2,7 @@
 <div class="relative w-full overflow-x-auto">
   <%= content_tag :table,
       class: Kiso::Themes::Table.render(class: css_classes),
-      data: kiso_prepare_options(component_options, component: :table),
+      data: kiso_prepare_options(component_options, slot: "table"),
       **component_options do %>
     <%= yield %>
   <% end %>

--- a/app/views/kiso/components/_textarea.html.erb
+++ b/app/views/kiso/components/_textarea.html.erb
@@ -3,7 +3,7 @@
 <% component_options[:disabled] = true if disabled %>
 <%= content_tag :textarea,
     class: Kiso::Themes::Textarea.render(variant: variant, size: size, class: css_classes),
-    data: kiso_prepare_options(component_options, component: :textarea),
+    data: kiso_prepare_options(component_options, slot: "textarea"),
     **component_options do %>
   <%= capture { yield }.presence %>
 <% end %>

--- a/app/views/kiso/components/_toggle.html.erb
+++ b/app/views/kiso/components/_toggle.html.erb
@@ -3,7 +3,7 @@
    component_options[:"aria-pressed"] = pressed %>
 <%= content_tag :button,
     class: Kiso::Themes::Toggle.render(variant: variant, size: size, class: css_classes),
-    data: kiso_prepare_options(component_options, component: :toggle,
+    data: kiso_prepare_options(component_options, slot: "toggle",
       state: pressed ? "on" : "off",
       controller: "kiso--toggle",
       action: "click->kiso--toggle#toggle"),

--- a/app/views/kiso/components/_toggle_group.html.erb
+++ b/app/views/kiso/components/_toggle_group.html.erb
@@ -2,7 +2,7 @@
 <%= content_tag :div,
     class: Kiso::Themes::ToggleGroup.render(class: css_classes),
     role: "group",
-    data: kiso_prepare_options(component_options, component: :toggle_group,
+    data: kiso_prepare_options(component_options, slot: "toggle-group",
       controller: "kiso--toggle-group",
       kiso__toggle_group_type_value: type,
       kiso__toggle_group_variant_value: variant,

--- a/app/views/kiso/components/alert/_description.html.erb
+++ b/app/views/kiso/components/alert/_description.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::AlertDescription.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :alert, alert_part: :description),
+    data: kiso_prepare_options(component_options, slot: "alert-description"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/alert/_title.html.erb
+++ b/app/views/kiso/components/alert/_title.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::AlertTitle.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :alert, alert_part: :title),
+    data: kiso_prepare_options(component_options, slot: "alert-title"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/breadcrumb/_ellipsis.html.erb
+++ b/app/views/kiso/components/breadcrumb/_ellipsis.html.erb
@@ -3,7 +3,7 @@
     class: Kiso::Themes::BreadcrumbEllipsis.render(class: css_classes),
     role: "presentation",
     aria: { hidden: "true" },
-    data: kiso_prepare_options(component_options, component: :breadcrumb, breadcrumb_part: :ellipsis),
+    data: kiso_prepare_options(component_options, slot: "breadcrumb-ellipsis"),
     **component_options do %>
   <%= kiso_icon "ellipsis", class: "size-4" %>
   <span class="sr-only">More</span>

--- a/app/views/kiso/components/breadcrumb/_item.html.erb
+++ b/app/views/kiso/components/breadcrumb/_item.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :li,
     class: Kiso::Themes::BreadcrumbItem.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :breadcrumb, breadcrumb_part: :item),
+    data: kiso_prepare_options(component_options, slot: "breadcrumb-item"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/breadcrumb/_link.html.erb
+++ b/app/views/kiso/components/breadcrumb/_link.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :a,
     class: Kiso::Themes::BreadcrumbLink.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :breadcrumb, breadcrumb_part: :link),
+    data: kiso_prepare_options(component_options, slot: "breadcrumb-link"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/breadcrumb/_list.html.erb
+++ b/app/views/kiso/components/breadcrumb/_list.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :ol,
     class: Kiso::Themes::BreadcrumbList.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :breadcrumb, breadcrumb_part: :list),
+    data: kiso_prepare_options(component_options, slot: "breadcrumb-list"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/breadcrumb/_page.html.erb
+++ b/app/views/kiso/components/breadcrumb/_page.html.erb
@@ -3,7 +3,7 @@
     class: Kiso::Themes::BreadcrumbPage.render(class: css_classes),
     role: "link",
     aria: { disabled: "true", current: "page" },
-    data: kiso_prepare_options(component_options, component: :breadcrumb, breadcrumb_part: :page),
+    data: kiso_prepare_options(component_options, slot: "breadcrumb-page"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/breadcrumb/_separator.html.erb
+++ b/app/views/kiso/components/breadcrumb/_separator.html.erb
@@ -3,7 +3,7 @@
     class: Kiso::Themes::BreadcrumbSeparator.render(class: css_classes),
     role: "presentation",
     aria: { hidden: "true" },
-    data: kiso_prepare_options(component_options, component: :breadcrumb, breadcrumb_part: :separator),
+    data: kiso_prepare_options(component_options, slot: "breadcrumb-separator"),
     **component_options do %>
   <%= capture { yield }.presence || kiso_icon("chevron-right", class: "size-3.5") %>
 <% end %>

--- a/app/views/kiso/components/card/_action.html.erb
+++ b/app/views/kiso/components/card/_action.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::CardAction.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :card, card_part: :action),
+    data: kiso_prepare_options(component_options, slot: "card-action"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/card/_content.html.erb
+++ b/app/views/kiso/components/card/_content.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::CardContent.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :card, card_part: :content),
+    data: kiso_prepare_options(component_options, slot: "card-content"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/card/_description.html.erb
+++ b/app/views/kiso/components/card/_description.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::CardDescription.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :card, card_part: :description),
+    data: kiso_prepare_options(component_options, slot: "card-description"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/card/_footer.html.erb
+++ b/app/views/kiso/components/card/_footer.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::CardFooter.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :card, card_part: :footer),
+    data: kiso_prepare_options(component_options, slot: "card-footer"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/card/_header.html.erb
+++ b/app/views/kiso/components/card/_header.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::CardHeader.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :card, card_part: :header),
+    data: kiso_prepare_options(component_options, slot: "card-header"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/card/_title.html.erb
+++ b/app/views/kiso/components/card/_title.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::CardTitle.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :card, card_part: :title),
+    data: kiso_prepare_options(component_options, slot: "card-title"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/empty/_content.html.erb
+++ b/app/views/kiso/components/empty/_content.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::EmptyContent.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :empty, empty_part: :content),
+    data: kiso_prepare_options(component_options, slot: "empty-content"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/empty/_description.html.erb
+++ b/app/views/kiso/components/empty/_description.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::EmptyDescription.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :empty, empty_part: :description),
+    data: kiso_prepare_options(component_options, slot: "empty-description"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/empty/_header.html.erb
+++ b/app/views/kiso/components/empty/_header.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::EmptyHeader.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :empty, empty_part: :header),
+    data: kiso_prepare_options(component_options, slot: "empty-header"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/empty/_media.html.erb
+++ b/app/views/kiso/components/empty/_media.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (variant: :default, css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::EmptyMedia.render(variant: variant, class: css_classes),
-    data: kiso_prepare_options(component_options, component: :empty, empty_part: :media),
+    data: kiso_prepare_options(component_options, slot: "empty-media"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/empty/_title.html.erb
+++ b/app/views/kiso/components/empty/_title.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::EmptyTitle.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :empty, empty_part: :title),
+    data: kiso_prepare_options(component_options, slot: "empty-title"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/field/_content.html.erb
+++ b/app/views/kiso/components/field/_content.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::FieldContent.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :field, field_part: :content),
+    data: kiso_prepare_options(component_options, slot: "field-content"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/field/_description.html.erb
+++ b/app/views/kiso/components/field/_description.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :p,
     class: Kiso::Themes::FieldDescription.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :field, field_part: :description),
+    data: kiso_prepare_options(component_options, slot: "field-description"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/field/_error.html.erb
+++ b/app/views/kiso/components/field/_error.html.erb
@@ -5,7 +5,7 @@
   <%= content_tag :div,
       role: :alert,
       class: Kiso::Themes::FieldError.render(class: css_classes),
-      data: kiso_prepare_options(component_options, component: :field, field_part: :error),
+      data: kiso_prepare_options(component_options, slot: "field-error"),
       **component_options do %>
     <% if content %>
       <%= content %>

--- a/app/views/kiso/components/field/_label.html.erb
+++ b/app/views/kiso/components/field/_label.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (css_classes: "", **component_options) %>
-<% component_options[:data] = (component_options[:data] || {}).merge(field_part: :label) %>
+<% component_options[:data] = (component_options[:data] || {}).merge(slot: "field-label") %>
 <%= kui(:label,
     css_classes: Kiso::Themes::FieldLabel.render(class: css_classes),
     **component_options) { yield } %>

--- a/app/views/kiso/components/field/_separator.html.erb
+++ b/app/views/kiso/components/field/_separator.html.erb
@@ -2,7 +2,7 @@
 <% captured = capture { yield }.presence %>
 <%= content_tag :div,
     class: Kiso::Themes::FieldSeparator.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :field, field_part: :separator).merge(
+    data: kiso_prepare_options(component_options, slot: "field-separator").merge(
       content: captured&.present? || nil
     ).compact,
     **component_options do %>

--- a/app/views/kiso/components/field/_title.html.erb
+++ b/app/views/kiso/components/field/_title.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::FieldTitle.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :field, field_part: :title),
+    data: kiso_prepare_options(component_options, slot: "field-title"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/field_set/_legend.html.erb
+++ b/app/views/kiso/components/field_set/_legend.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (variant: :legend, css_classes: "", **component_options) %>
 <%= content_tag :legend,
     class: Kiso::Themes::FieldLegend.render(variant: variant, class: css_classes),
-    data: kiso_prepare_options(component_options, component: :field_set, field_set_part: :legend).merge(
+    data: kiso_prepare_options(component_options, slot: "field-set-legend").merge(
       variant: variant
     ),
     **component_options do %>

--- a/app/views/kiso/components/input_group/_addon.html.erb
+++ b/app/views/kiso/components/input_group/_addon.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (align: :start, css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::InputGroupAddon.render(align: align, class: css_classes),
-    data: kiso_prepare_options(component_options, component: :input_group, input_group_part: :addon),
+    data: kiso_prepare_options(component_options, slot: "input-group-addon"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/pagination/_content.html.erb
+++ b/app/views/kiso/components/pagination/_content.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :ul,
     class: Kiso::Themes::PaginationContent.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :pagination, pagination_part: :content),
+    data: kiso_prepare_options(component_options, slot: "pagination-content"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/pagination/_ellipsis.html.erb
+++ b/app/views/kiso/components/pagination/_ellipsis.html.erb
@@ -2,7 +2,7 @@
 <%= content_tag :span,
     aria: {hidden: true},
     class: Kiso::Themes::PaginationEllipsis.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :pagination, pagination_part: :ellipsis),
+    data: kiso_prepare_options(component_options, slot: "pagination-ellipsis"),
     **component_options do %>
   <%= kiso_icon("ellipsis", size: :sm) %>
   <%= content_tag :span, "More pages", class: "sr-only" %>

--- a/app/views/kiso/components/pagination/_item.html.erb
+++ b/app/views/kiso/components/pagination/_item.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :li,
     class: Kiso::Themes::PaginationItem.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :pagination, pagination_part: :item),
+    data: kiso_prepare_options(component_options, slot: "pagination-item"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/pagination/_link.html.erb
+++ b/app/views/kiso/components/pagination/_link.html.erb
@@ -3,7 +3,7 @@
     href: href,
     **(active ? {aria: {current: "page"}} : {}),
     class: Kiso::Themes::PaginationLink.render(active: active, class: css_classes),
-    data: kiso_prepare_options(component_options, component: :pagination, pagination_part: :link, active: active),
+    data: kiso_prepare_options(component_options, slot: "pagination-link", active: active),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/pagination/_next.html.erb
+++ b/app/views/kiso/components/pagination/_next.html.erb
@@ -5,7 +5,7 @@
     href: href,
     aria: aria_attrs,
     class: Kiso::Themes::PaginationNext.render(active: active, class: css_classes),
-    data: kiso_prepare_options(component_options, component: :pagination, pagination_part: :next),
+    data: kiso_prepare_options(component_options, slot: "pagination-next"),
     **component_options do %>
   <%= content_tag :span, "Next", class: "hidden sm:block" %>
   <%= kiso_icon("chevron-right") %>

--- a/app/views/kiso/components/pagination/_previous.html.erb
+++ b/app/views/kiso/components/pagination/_previous.html.erb
@@ -5,7 +5,7 @@
     href: href,
     aria: aria_attrs,
     class: Kiso::Themes::PaginationPrevious.render(active: active, class: css_classes),
-    data: kiso_prepare_options(component_options, component: :pagination, pagination_part: :previous),
+    data: kiso_prepare_options(component_options, slot: "pagination-previous"),
     **component_options do %>
   <%= kiso_icon("chevron-left") %>
   <%= content_tag :span, "Previous", class: "hidden sm:block" %>

--- a/app/views/kiso/components/radio_group/_item.html.erb
+++ b/app/views/kiso/components/radio_group/_item.html.erb
@@ -2,5 +2,5 @@
 <% component_options[:type] = :radio %>
 <%= tag.input(
     class: Kiso::Themes::RadioGroupItem.render(color: color, class: css_classes),
-    data: kiso_prepare_options(component_options, component: :radio_group, radio_group_part: :item),
+    data: kiso_prepare_options(component_options, slot: "radio-group-item"),
     **component_options) %>

--- a/app/views/kiso/components/stats_card/_description.html.erb
+++ b/app/views/kiso/components/stats_card/_description.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::StatsCardDescription.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :stats_card, stats_card_part: :description),
+    data: kiso_prepare_options(component_options, slot: "stats-card-description"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/stats_card/_header.html.erb
+++ b/app/views/kiso/components/stats_card/_header.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::StatsCardHeader.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :stats_card, stats_card_part: :header),
+    data: kiso_prepare_options(component_options, slot: "stats-card-header"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/stats_card/_label.html.erb
+++ b/app/views/kiso/components/stats_card/_label.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::StatsCardLabel.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :stats_card, stats_card_part: :label),
+    data: kiso_prepare_options(component_options, slot: "stats-card-label"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/stats_card/_value.html.erb
+++ b/app/views/kiso/components/stats_card/_value.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :div,
     class: Kiso::Themes::StatsCardValue.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :stats_card, stats_card_part: :value),
+    data: kiso_prepare_options(component_options, slot: "stats-card-value"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/table/_body.html.erb
+++ b/app/views/kiso/components/table/_body.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :tbody,
     class: Kiso::Themes::TableBody.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :table, table_part: :body),
+    data: kiso_prepare_options(component_options, slot: "table-body"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/table/_caption.html.erb
+++ b/app/views/kiso/components/table/_caption.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :caption,
     class: Kiso::Themes::TableCaption.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :table, table_part: :caption),
+    data: kiso_prepare_options(component_options, slot: "table-caption"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/table/_cell.html.erb
+++ b/app/views/kiso/components/table/_cell.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :td,
     class: Kiso::Themes::TableCell.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :table, table_part: :cell),
+    data: kiso_prepare_options(component_options, slot: "table-cell"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/table/_footer.html.erb
+++ b/app/views/kiso/components/table/_footer.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :tfoot,
     class: Kiso::Themes::TableFooter.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :table, table_part: :footer),
+    data: kiso_prepare_options(component_options, slot: "table-footer"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/table/_head.html.erb
+++ b/app/views/kiso/components/table/_head.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :th,
     class: Kiso::Themes::TableHead.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :table, table_part: :head),
+    data: kiso_prepare_options(component_options, slot: "table-head"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/table/_header.html.erb
+++ b/app/views/kiso/components/table/_header.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :thead,
     class: Kiso::Themes::TableHeader.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :table, table_part: :header),
+    data: kiso_prepare_options(component_options, slot: "table-header"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/table/_row.html.erb
+++ b/app/views/kiso/components/table/_row.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (css_classes: "", **component_options) %>
 <%= content_tag :tr,
     class: Kiso::Themes::TableRow.render(class: css_classes),
-    data: kiso_prepare_options(component_options, component: :table, table_part: :row),
+    data: kiso_prepare_options(component_options, slot: "table-row"),
     **component_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/kiso/components/toggle_group/_item.html.erb
+++ b/app/views/kiso/components/toggle_group/_item.html.erb
@@ -3,7 +3,7 @@
    component_options[:"aria-pressed"] = pressed %>
 <%= content_tag :button,
     class: Kiso::Themes::ToggleGroupItem.render(variant: variant, size: size, class: css_classes),
-    data: kiso_prepare_options(component_options, component: :toggle_group, toggle_group_part: :item,
+    data: kiso_prepare_options(component_options, slot: "toggle-group-item",
       state: pressed ? "on" : "off",
       value: value,
       kiso__toggle_group_target: "item",

--- a/docs/src/components/alert.md
+++ b/docs/src/components/alert.md
@@ -134,7 +134,7 @@ Kiso::Themes::AlertDescription = ClassVariants.build(
 | Attribute | Value |
 |-----------|-------|
 | `role` | `alert` |
-| `data-component` | `"alert"` |
+| `data-slot` | `"alert"` |
 
 The `role="alert"` attribute is set automatically. Screen readers will
 announce alert content when it appears.

--- a/docs/src/components/badge.md
+++ b/docs/src/components/badge.md
@@ -141,7 +141,7 @@ Kiso::Themes::Badge = ClassVariants.build(
 
 | Attribute | Value |
 |-----------|-------|
-| `data-component` | `"badge"` |
+| `data-slot` | `"badge"` |
 
 Badges are decorative by default. If a badge conveys meaningful status,
 add `aria-label:` via component options:

--- a/docs/src/components/button.md
+++ b/docs/src/components/button.md
@@ -193,7 +193,7 @@ focus-visible states:
 
 | Attribute | Value |
 |-----------|-------|
-| `data-component` | `"button"` |
+| `data-slot` | `"button"` |
 | `type` | `"button"` (default, not `"submit"`) |
 | `disabled` | Native attribute on `<button>` |
 | `aria-disabled` | Set on `<a>` when `disabled: true` |

--- a/docs/src/components/card.md
+++ b/docs/src/components/card.md
@@ -128,8 +128,8 @@ CardFooter      = ClassVariants.build(base: "flex items-center px-6")
 
 ## Accessibility
 
-Card renders a `<div>` with `data-component="card"`. Sub-parts use
-`data-card-part` attributes for identity.
+Card renders a `<div>` with `data-slot="card"`. Sub-parts use
+`data-slot` attributes (e.g., `data-slot="card-header"`).
 
 For semantic meaning, use `component_options` to set a role:
 

--- a/docs/src/components/checkbox.md
+++ b/docs/src/components/checkbox.md
@@ -99,7 +99,7 @@ SVG (Lucide Check icon). The `currentColor` inherits from
 
 | Attribute | Value |
 |-----------|-------|
-| `data-component` | `"checkbox"` |
+| `data-slot` | `"checkbox"` |
 | `type` | `"checkbox"` |
 | `aria-invalid` | Set when validation fails |
 | `disabled` | Native attribute |

--- a/docs/src/components/empty.md
+++ b/docs/src/components/empty.md
@@ -154,8 +154,8 @@ EmptyContent     = ClassVariants.build(base: "flex w-full max-w-sm min-w-0 flex-
 
 ## Accessibility
 
-Empty renders as a `<div>` with `data-component="empty"`. Sub-parts
-use `data-empty-part` attributes for identity.
+Empty renders as a `<div>` with `data-slot="empty"`. Sub-parts
+use `data-slot` attributes (e.g., `data-slot="empty-header"`).
 
 For semantic meaning, use `component_options` to set a role:
 

--- a/docs/src/components/input.md
+++ b/docs/src/components/input.md
@@ -128,7 +128,7 @@ Kiso::Themes::Input = ClassVariants.build(
 
 | Attribute | Value |
 |-----------|-------|
-| `data-component` | `"input"` |
+| `data-slot` | `"input"` |
 | `aria-invalid` | Set when validation fails |
 | `disabled` | Native attribute |
 

--- a/docs/src/components/input_group.md
+++ b/docs/src/components/input_group.md
@@ -114,7 +114,7 @@ Kiso::Themes::InputGroupAddon = ClassVariants.build(
 | Attribute | Value |
 |-----------|-------|
 | `role` | `"group"` on the container |
-| `data-component` | `"input_group"` |
+| `data-slot` | `"input-group"` |
 
 Focus and error states bubble up from the child input via `has-[:focus-visible]`
 and `has-[[aria-invalid]]` selectors on the container.

--- a/docs/src/components/pagination.md
+++ b/docs/src/components/pagination.md
@@ -137,7 +137,7 @@ Omit page numbers entirely for simple sequential navigation.
 
 | Attribute | Value |
 |-----------|-------|
-| `data-component` | `"pagination"` |
+| `data-slot` | `"pagination"` |
 | `role` on nav | `"navigation"` |
 | `aria-label` on nav | `"pagination"` |
 | `aria-current` on active link | `"page"` |

--- a/docs/src/components/radio_group.md
+++ b/docs/src/components/radio_group.md
@@ -169,7 +169,7 @@ background. The `currentColor` inherits from `checked:text-{color}-foreground`.
 
 | Attribute | Value |
 |-----------|-------|
-| `data-component` | `"radio_group"` |
+| `data-slot` | `"radio-group"` |
 | `role` | `"radiogroup"` (on container) |
 | `type` | `"radio"` (on each item) |
 | `aria-invalid` | Set when validation fails |

--- a/docs/src/components/separator.md
+++ b/docs/src/components/separator.md
@@ -98,7 +98,7 @@ Kiso::Themes::Separator = ClassVariants.build(
 
 | Attribute | Value |
 |-----------|-------|
-| `data-component` | `"separator"` |
+| `data-slot` | `"separator"` |
 | `role` | `"none"` (decorative) or `"separator"` (semantic) |
 | `aria-orientation` | Set when `decorative: false` |
 

--- a/docs/src/components/stats_card.md
+++ b/docs/src/components/stats_card.md
@@ -151,5 +151,5 @@ StatsGrid = ClassVariants.build(
 
 ## Accessibility
 
-Stats Card renders as a `<div>` with `data-component="stats_card"`. Sub-parts
-use `data-stats-card-part` attributes for identity.
+Stats Card renders as a `<div>` with `data-slot="stats-card"`. Sub-parts
+use `data-slot` attributes (e.g., `data-slot="stats-card-header"`).

--- a/docs/src/components/switch.md
+++ b/docs/src/components/switch.md
@@ -132,7 +132,7 @@ input and a thumb `<span>`. `has-[:checked]` drives the track color,
 
 | Attribute | Value |
 |-----------|-------|
-| `data-component` | `"switch"` |
+| `data-slot` | `"switch"` |
 | `role` | `"switch"` |
 | `type` | `"checkbox"` |
 | `disabled` | Native attribute |

--- a/docs/src/components/textarea.md
+++ b/docs/src/components/textarea.md
@@ -105,7 +105,7 @@ Kiso::Themes::Textarea = ClassVariants.build(
 
 | Attribute | Value |
 |-----------|-------|
-| `data-component` | `"textarea"` |
+| `data-slot` | `"textarea"` |
 | `aria-invalid` | Set when validation fails |
 | `disabled` | Native attribute |
 

--- a/docs/src/components/toggle.md
+++ b/docs/src/components/toggle.md
@@ -121,7 +121,7 @@ on click.
 |-----------|-------|
 | `aria-pressed` | `true` / `false` |
 | `data-state` | `"on"` / `"off"` |
-| `data-component` | `"toggle"` |
+| `data-slot` | `"toggle"` |
 
 ### Keyboard
 

--- a/lib/kiso/cli/make.rb
+++ b/lib/kiso/cli/make.rb
@@ -217,11 +217,12 @@ class Kiso::Cli::Make < Kiso::Cli::Base
   # -- Partial templates --
 
   def colored_partial_template
+    slot = @name.tr("_", "-")
     <<~ERB
       <%# locals: (color: :primary, variant: :soft, size: :md, css_classes: "", **component_options) %>
       <%= content_tag :div,
           class: Kiso::Themes::#{@class_name}.render(color: color, variant: variant, size: size, class: css_classes),
-          data: kiso_prepare_options(component_options, component: :#{@name}),
+          data: kiso_prepare_options(component_options, slot: "#{slot}"),
           **component_options do %>
         <%= yield %>
       <% end %>
@@ -229,11 +230,12 @@ class Kiso::Cli::Make < Kiso::Cli::Base
   end
 
   def simple_partial_template
+    slot = @name.tr("_", "-")
     <<~ERB
       <%# locals: (variant: :default, size: :md, css_classes: "", **component_options) %>
       <%= content_tag :div,
           class: Kiso::Themes::#{@class_name}.render(variant: variant, size: size, class: css_classes),
-          data: kiso_prepare_options(component_options, component: :#{@name}),
+          data: kiso_prepare_options(component_options, slot: "#{slot}"),
           **component_options do %>
         <%= yield %>
       <% end %>

--- a/lib/kiso/themes/field.rb
+++ b/lib/kiso/themes/field.rb
@@ -8,14 +8,14 @@ module Kiso
         orientation: {
           vertical: "flex-col [&>*]:w-full [&>.sr-only]:w-auto",
           horizontal: "flex-row items-center " \
-                      "[&>[data-field-part=label]]:flex-auto " \
-                      "has-[>[data-field-part=content]]:items-start " \
-                      "has-[>[data-field-part=content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+                      "[&>[data-slot=field-label]]:flex-auto " \
+                      "has-[>[data-slot=field-content]]:items-start " \
+                      "has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
           responsive: "flex-col [&>*]:w-full [&>.sr-only]:w-auto " \
                       "@md/field-group:flex-row @md/field-group:items-center @md/field-group:[&>*]:w-auto " \
-                      "@md/field-group:[&>[data-field-part=label]]:flex-auto " \
-                      "@md/field-group:has-[>[data-field-part=content]]:items-start " \
-                      "@md/field-group:has-[>[data-field-part=content]]:[&>[role=checkbox],[role=radio]]:mt-px"
+                      "@md/field-group:[&>[data-slot=field-label]]:flex-auto " \
+                      "@md/field-group:has-[>[data-slot=field-content]]:items-start " \
+                      "@md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px"
         }
       },
       defaults: {orientation: :vertical}
@@ -32,9 +32,9 @@ module Kiso
     FieldLabel = ClassVariants.build(
       base: "group/field-label peer/field-label flex w-fit gap-2 leading-snug " \
             "group-data-[disabled=true]/field:opacity-50 " \
-            "has-[>[data-component=field]]:w-full has-[>[data-component=field]]:flex-col " \
-            "has-[>[data-component=field]]:rounded-md has-[>[data-component=field]]:border " \
-            "[&>*[data-component=field]]:p-4"
+            "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col " \
+            "has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border " \
+            "[&>*[data-slot=field]]:p-4"
     )
 
     # shadcn: flex w-fit items-center gap-2 text-sm leading-snug font-medium

--- a/lib/kiso/themes/field_group.rb
+++ b/lib/kiso/themes/field_group.rb
@@ -4,7 +4,7 @@ module Kiso
     #         [&>[data-slot=field-group]]:gap-4
     FieldGroup = ClassVariants.build(
       base: "group/field-group @container/field-group flex w-full flex-col gap-7 " \
-            "[&>[data-component=field_group]]:gap-4"
+            "[&>[data-slot=field-group]]:gap-4"
     )
   end
 end

--- a/lib/kiso/themes/field_set.rb
+++ b/lib/kiso/themes/field_set.rb
@@ -4,8 +4,8 @@ module Kiso
     #         has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3
     FieldSet = ClassVariants.build(
       base: "flex flex-col gap-6 " \
-            "has-[>[data-component=checkbox_group]]:gap-3 " \
-            "has-[>[data-component=radio_group]]:gap-3"
+            "has-[>[data-slot=checkbox-group]]:gap-3 " \
+            "has-[>[data-slot=radio-group]]:gap-3"
     )
 
     # shadcn: mb-3 font-medium + variant (legend: text-base, label: text-sm)

--- a/project/AGENTIC_COMPONENT_FACTORY.md
+++ b/project/AGENTIC_COMPONENT_FACTORY.md
@@ -109,7 +109,7 @@ A quality gate agent (~150 lines) with a 10-point checklist:
 | 3 | Tailwind classes match shadcn for layout/spacing/typography |
 | 4 | Compound variant formulas match the design system (if colored) |
 | 5 | `text-foreground` set on container roots (dark mode) |
-| 6 | Data attributes use `kiso_prepare_options` helper |
+| 6 | `data-slot` set via `kiso_prepare_options(slot: "...")` helper |
 | 7 | All deliverables present (theme, partials, previews, docs, nav, ref) |
 | 8 | PR body contains `Closes #N` |
 | 9 | No arbitrary Tailwind values |

--- a/project/COMPONENT_DOC_TEMPLATE.md
+++ b/project/COMPONENT_DOC_TEMPLATE.md
@@ -110,7 +110,7 @@ Kiso::Themes::ComponentName = ClassVariants.build(
 | Attribute | Value |
 |-----------|-------|
 | `role` | `alert` |
-| `data-component` | `"alert"` |
+| `data-slot` | `"alert"` |
 
 ### Keyboard
 

--- a/project/COMPONENT_STRATEGY.md
+++ b/project/COMPONENT_STRATEGY.md
@@ -229,7 +229,7 @@ dark mode happens automatically.
 Or in component CSS:
 
 ```css
-[data-component="button"][data-variant="primary"] {
+[data-slot="button"] {
   @apply bg-primary text-primary-foreground hover:bg-primary/90;
 }
 ```
@@ -769,25 +769,24 @@ and class_variants for the classes in ERB:
 ```css
 /* app/assets/stylesheets/button.css */
 /* Transitions, animations — things hard to express in ERB */
-[data-component="button"] {
+[data-slot="button"] {
   @apply transition-colors duration-150;
 }
 
-[data-component="button"]:focus-visible {
+[data-slot="button"]:focus-visible {
   @apply outline-2 outline-offset-2 outline-ring;
 }
 ```
 
 ```erb
 <%# ERB handles variant classes — the bulk of the styling %>
-<button
-  class="<%= Kiso::Themes::Button.render(color: color, variant: variant,
-               size: size, class: css_classes) %>"
-  data-component="button"
-  data-variant="<%= variant %>"
-  data-size="<%= size %>">
+<%= content_tag :button,
+    class: Kiso::Themes::Button.render(color: color, variant: variant,
+               size: size, class: css_classes),
+    data: kiso_prepare_options(component_options, slot: "button"),
+    **component_options do %>
   <%= yield %>
-</button>
+<% end %>
 ```
 
 The data attributes serve as **hooks for CSS that's awkward in ERB** (pseudo-
@@ -1048,7 +1047,7 @@ end
 ### What to Leave Behind
 
 - **BEM naming** (`unio-button--scheme-primary`) — Kiso uses
-  `data-component` / `data-variant` attributes instead. Same purpose
+  `data-slot` attributes (shadcn v4 convention) instead. Same purpose
   (CSS hooks, debugging, test selectors), less class noise.
 - **Hardcoded colors** (`bg-sky-600`, `text-gray-500`) — Kiso uses
   semantic tokens (`bg-primary`, `text-muted-foreground`). No dark mode
@@ -1415,7 +1414,7 @@ transitions for `<dialog>`. No animation JS needed.
   is good enough and universally understood.
 
 - **BEM-ish class naming** (`.btn--link`, `.panel--centered`) — Kiso uses
-  `data-component` / `data-variant` attributes, which serve the same purpose
+  `data-slot` attributes (shadcn v4 convention), which serve the same purpose
   without class noise. Though Fizzy's naming is clean and consistent.
 
 - **CSS-only variant system** — Fizzy's "override custom properties for


### PR DESCRIPTION
## Summary

- Replace `data-component` / `data-*-part` attributes with `data-slot` across all components, matching shadcn v4's identity convention
- Enables contextual CSS targeting via `has-[[data-slot=...]]` selectors (already used by shadcn for layout-aware styling)
- Single flat attribute (`data-slot="card-header"`) replaces the two-pattern system (`data-component="card"` + `data-card-part="header"`)
- Stimulus controllers remain orthogonal — added separately via `data-controller` when behavior is needed

### Changes

| Area | Count | Detail |
|------|-------|--------|
| Helper | 1 file | `kiso_prepare_options` accepts `slot:` keyword; removed unused `component_tag` |
| ERB partials | 68 files | All use `slot: "kebab-case-name"` |
| Theme files | 3 files | CSS selectors updated (`[data-slot=field]`, etc.) |
| CLI generator | 1 file | Templates use `slot:` with kebab-case |
| Documentation | ~15 files | CLAUDE.md, VISION.md, agents, skills, docs pages |

### Naming convention

- Root: `data-slot="card"`, `data-slot="badge"`
- Multi-word: `data-slot="toggle-group"`, `data-slot="stats-card"` (kebab-case)
- Sub-parts: `data-slot="card-header"`, `data-slot="field-content"`

## Test plan

- [x] `bundle exec standardrb --fix` passes
- [x] `bundle exec rake test` passes
- [x] Lookbook server starts and returns 200
- [ ] Visually verify components render in Lookbook
- [ ] Verify Field/FieldSet contextual CSS works (horizontal layout, checkbox group gap)