### PR TITLE
feat: Kbd component

### DIFF
--- a/app/views/kiso/components/_kbd.html.erb
+++ b/app/views/kiso/components/_kbd.html.erb
@@ -1,0 +1,7 @@
+<%# locals: (size: :md, css_classes: "", **component_options) %>
+<%= content_tag :kbd,
+    class: Kiso::Themes::Kbd.render(size: size, class: css_classes),
+    data: kiso_prepare_options(component_options, slot: "kbd"),
+    **component_options do %>
+  <%= yield %>
+<% end %>

--- a/app/views/kiso/components/kbd/_group.html.erb
+++ b/app/views/kiso/components/kbd/_group.html.erb
@@ -1,0 +1,7 @@
+<%# locals: (css_classes: "", **component_options) %>
+<%= content_tag :kbd,
+    class: Kiso::Themes::KbdGroup.render(class: css_classes),
+    data: kiso_prepare_options(component_options, slot: "kbd-group"),
+    **component_options do %>
+  <%= yield %>
+<% end %>

--- a/docs/src/_data/navigation.yml
+++ b/docs/src/_data/navigation.yml
@@ -43,6 +43,8 @@ docs:
         href: /components/dropdown_menu
       - title: Empty
         href: /components/empty
+      - title: Kbd
+        href: /components/kbd
       - title: Pagination
         href: /components/pagination
       - title: Popover

--- a/docs/src/components/kbd.md
+++ b/docs/src/components/kbd.md
@@ -1,0 +1,138 @@
+---
+title: Kbd
+layout: docs
+description: Displays a keyboard key or shortcut inline.
+category: Element
+source: lib/kiso/themes/kbd.rb
+---
+
+## Quick Start
+
+```erb
+<%%= kui(:kbd) { "⌘K" } %>
+```
+
+<%= render "component_preview", component: "kiso/kbd", scenario: "playground" %>
+
+## Locals
+
+| Local | Type | Default |
+|-------|------|---------|
+| `size:` | `:sm` \| `:md` \| `:lg` | `:md` |
+| `css_classes:` | `String` | `""` |
+| `**component_options` | `Hash` | `{}` |
+
+## Sub-parts
+
+| Part | Element | Description |
+|------|---------|-------------|
+| `:group` | `<kbd>` | Wraps multiple Kbd elements inline |
+
+## Usage
+
+### Modifier Symbols
+
+Display modifier keys as individual keycaps grouped together.
+
+```erb
+<%%= kui(:kbd, :group) do %>
+  <%%= kui(:kbd) { "⌘" } %>
+  <%%= kui(:kbd) { "⇧" } %>
+  <%%= kui(:kbd) { "⌥" } %>
+  <%%= kui(:kbd) { "⌃" } %>
+<%% end %>
+```
+
+### Key Combination
+
+Use a group with a separator for multi-key shortcuts.
+
+```erb
+<%%= kui(:kbd, :group) do %>
+  <%%= kui(:kbd) { "Ctrl" } %>
+  <span>+</span>
+  <%%= kui(:kbd) { "B" } %>
+<%% end %>
+```
+
+### Inline with Text
+
+Embed key references naturally in prose.
+
+```erb
+<p class="text-muted-foreground text-sm">
+  Use
+  <%%= kui(:kbd, :group) do %>
+    <%%= kui(:kbd) { "Ctrl + B" } %>
+    <%%= kui(:kbd) { "Ctrl + K" } %>
+  <%% end %>
+  to open the command palette
+</p>
+```
+
+### Sizes
+
+Three sizes match the spatial system.
+
+```erb
+<%%= kui(:kbd, size: :sm) { "⌘K" } %>
+<%%= kui(:kbd, size: :md) { "⌘K" } %>
+<%%= kui(:kbd, size: :lg) { "⌘K" } %>
+```
+
+### Inside a Button
+
+```erb
+<%%= kui(:button, variant: :outline) do %>
+  Accept <%%= kui(:kbd) { "⏎" } %>
+<%% end %>
+```
+
+### Inside an Input Group
+
+```erb
+<%%= kui(:input_group) do %>
+  <%%= kui(:input_group, :addon) do %>
+    <%%= kiso_icon("search", class: "size-4") %>
+  <%% end %>
+  <%%= kui(:input, placeholder: "Search...") %>
+  <%%= kui(:input_group, :addon, align: :end) do %>
+    <%%= kui(:kbd) { "⌘" } %>
+    <%%= kui(:kbd) { "K" } %>
+  <%% end %>
+<%% end %>
+```
+
+## Theme
+
+```ruby
+# lib/kiso/themes/kbd.rb
+Kiso::Themes::Kbd = ClassVariants.build(
+  base: "bg-muted text-muted-foreground pointer-events-none inline-flex items-center " \
+        "justify-center gap-1 rounded-sm font-sans font-medium select-none " \
+        "[&_svg:not([class*='size-'])]:size-3",
+  variants: {
+    size: {
+      sm: "h-4 min-w-4 px-0.5 text-xs",
+      md: "h-5 min-w-5 px-1 text-xs",
+      lg: "h-6 min-w-6 px-1.5 text-xs"
+    }
+  },
+  defaults: { size: :md }
+)
+
+Kiso::Themes::KbdGroup = ClassVariants.build(
+  base: "inline-flex items-center gap-1"
+)
+```
+
+## Accessibility
+
+The `<kbd>` element is semantic HTML that represents user keyboard input.
+Screen readers announce it as keyboard input without any additional ARIA
+attributes needed.
+
+| Attribute | Value |
+|-----------|-------|
+| `data-slot` | `"kbd"` / `"kbd-group"` |
+| Element | `<kbd>` (semantic HTML) |

--- a/lib/kiso.rb
+++ b/lib/kiso.rb
@@ -31,6 +31,7 @@ require "kiso/themes/popover"
 require "kiso/themes/combobox"
 require "kiso/themes/command"
 require "kiso/themes/dropdown_menu"
+require "kiso/themes/kbd"
 require "kiso/icons"
 
 module Kiso

--- a/lib/kiso/themes/kbd.rb
+++ b/lib/kiso/themes/kbd.rb
@@ -1,0 +1,26 @@
+module Kiso
+  module Themes
+    # shadcn Kbd:
+    #   bg-muted text-muted-foreground pointer-events-none inline-flex h-5 w-fit min-w-5
+    #   items-center justify-center gap-1 rounded-sm px-1 font-sans text-xs font-medium select-none
+    #   [&_svg:not([class*='size-'])]:size-3
+    Kbd = ClassVariants.build(
+      base: "bg-muted text-muted-foreground pointer-events-none inline-flex items-center " \
+            "justify-center gap-1 rounded-sm font-sans font-medium select-none " \
+            "[&_svg:not([class*='size-'])]:size-3",
+      variants: {
+        size: {
+          sm: "h-4 min-w-4 px-0.5 text-xs",
+          md: "h-5 min-w-5 px-1 text-xs",
+          lg: "h-6 min-w-6 px-1.5 text-xs"
+        }
+      },
+      defaults: {size: :md}
+    )
+
+    # shadcn KbdGroup: inline-flex items-center gap-1
+    KbdGroup = ClassVariants.build(
+      base: "inline-flex items-center gap-1"
+    )
+  end
+end

--- a/skills/kiso/references/components.md
+++ b/skills/kiso/references/components.md
@@ -51,6 +51,7 @@ All colored components use **identical compound variant formulas** — see `proj
 | Component | Key locals | Reference |
 |---|---|---|
 | `badge` | `color`, `variant` (solid/outline/soft/subtle), `size` (xs-xl) | [badge.md](components/badge.md) |
+| `kbd` | `size` (sm/md/lg). Sub-part: group | [kbd.md](components/kbd.md) |
 | `alert` | `color`, `variant` (solid/outline/soft/subtle) | [alert.md](components/alert.md) |
 | `button` | `color`, `variant` (solid/outline/soft/subtle/ghost/link), `size` (xs-xl) | [button.md](components/button.md) |
 | `toggle` | `variant` (default/outline), `size` (sm/default/lg), `pressed` | [toggle.md](components/toggle.md) |

--- a/skills/kiso/references/components/kbd.md
+++ b/skills/kiso/references/components/kbd.md
@@ -1,0 +1,47 @@
+# Kbd
+
+Displays a keyboard key or shortcut inline. Uses the semantic `<kbd>` HTML
+element.
+
+**Locals:** `size:` (sm/md/lg), `css_classes:`, `**component_options`
+
+**Defaults:** `size: :md`
+
+**Sub-parts:** `:group` (wraps multiple Kbd elements)
+
+```erb
+<%# Single key %>
+<%= kui(:kbd) { "⌘K" } %>
+
+<%# Modifier symbols grouped %>
+<%= kui(:kbd, :group) do %>
+  <%= kui(:kbd) { "⌘" } %>
+  <%= kui(:kbd) { "⇧" } %>
+  <%= kui(:kbd) { "⌥" } %>
+<% end %>
+
+<%# Key combination with separator %>
+<%= kui(:kbd, :group) do %>
+  <%= kui(:kbd) { "Ctrl" } %>
+  <span>+</span>
+  <%= kui(:kbd) { "B" } %>
+<% end %>
+
+<%# Inside a button %>
+<%= kui(:button, variant: :outline) do %>
+  Accept <%= kui(:kbd) { "⏎" } %>
+<% end %>
+
+<%# Inside an input group %>
+<%= kui(:input_group, :addon, align: :end) do %>
+  <%= kui(:kbd) { "⌘" } %>
+  <%= kui(:kbd) { "K" } %>
+<% end %>
+
+<%# Sizes %>
+<%= kui(:kbd, size: :sm) { "A" } %>
+<%= kui(:kbd, size: :md) { "B" } %>
+<%= kui(:kbd, size: :lg) { "C" } %>
+```
+
+**Theme module:** `Kiso::Themes::Kbd`, `Kiso::Themes::KbdGroup` (`lib/kiso/themes/kbd.rb`)

--- a/test/components/previews/kiso/command_preview/dialog.html.erb
+++ b/test/components/previews/kiso/command_preview/dialog.html.erb
@@ -1,9 +1,7 @@
 <div class="text-foreground">
   <p class="text-muted-foreground text-sm">
     Press
-    <kbd class="bg-muted text-muted-foreground pointer-events-none inline-flex h-5 items-center gap-1 rounded border border-border px-1.5 font-mono text-[10px] font-medium opacity-100 select-none">
-      <span class="text-xs">⌘</span>K
-    </kbd>
+    <%= kui(:kbd) { "⌘K" } %>
   </p>
   <%= kui(:command, :dialog) do %>
     <%= kui(:command) do %>

--- a/test/components/previews/kiso/input_group_preview/prefix_and_suffix.html.erb
+++ b/test/components/previews/kiso/input_group_preview/prefix_and_suffix.html.erb
@@ -15,7 +15,7 @@
     <% end %>
     <%= kui(:input, type: :text, placeholder: "Search...") %>
     <%= kui(:input_group, :addon, align: :end) do %>
-      <kbd class="inline-flex items-center rounded border bg-muted px-1.5 text-xs text-muted-foreground">⌘K</kbd>
+      <%= kui(:kbd) { "⌘K" } %>
     <% end %>
   <% end %>
 </div>

--- a/test/components/previews/kiso/kbd_preview.rb
+++ b/test/components/previews/kiso/kbd_preview.rb
@@ -1,0 +1,36 @@
+module Kiso
+  # @label Kbd
+  class KbdPreview < Lookbook::Preview
+    # @label Playground
+    # @param size select { choices: [sm, md, lg] }
+    # @param text text "⌘K"
+    def playground(size: :md, text: "⌘K")
+      render_with_template(locals: {size: size.to_sym, text: text})
+    end
+
+    # @label Demo
+    def demo
+      render_with_template
+    end
+
+    # @label Group
+    def group
+      render_with_template
+    end
+
+    # @label Sizes
+    def sizes
+      render_with_template
+    end
+
+    # @label Button
+    def button
+      render_with_template
+    end
+
+    # @label Input Group
+    def input_group
+      render_with_template
+    end
+  end
+end

--- a/test/components/previews/kiso/kbd_preview/button.html.erb
+++ b/test/components/previews/kiso/kbd_preview/button.html.erb
@@ -1,0 +1,6 @@
+<div class="text-foreground flex items-center justify-center p-8">
+  <%= kui(:button, variant: :outline) do %>
+    Accept
+    <%= kui(:kbd, css_classes: "translate-x-0.5") { "⏎" } %>
+  <% end %>
+</div>

--- a/test/components/previews/kiso/kbd_preview/demo.html.erb
+++ b/test/components/previews/kiso/kbd_preview/demo.html.erb
@@ -1,0 +1,13 @@
+<div class="text-foreground flex flex-col items-center gap-4">
+  <%= kui(:kbd, :group) do %>
+    <%= kui(:kbd) { "⌘" } %>
+    <%= kui(:kbd) { "⇧" } %>
+    <%= kui(:kbd) { "⌥" } %>
+    <%= kui(:kbd) { "⌃" } %>
+  <% end %>
+  <%= kui(:kbd, :group) do %>
+    <%= kui(:kbd) { "Ctrl" } %>
+    <span>+</span>
+    <%= kui(:kbd) { "B" } %>
+  <% end %>
+</div>

--- a/test/components/previews/kiso/kbd_preview/group.html.erb
+++ b/test/components/previews/kiso/kbd_preview/group.html.erb
@@ -1,0 +1,10 @@
+<div class="text-foreground flex flex-col items-center gap-4">
+  <p class="text-muted-foreground text-sm">
+    Use
+    <%= kui(:kbd, :group) do %>
+      <%= kui(:kbd) { "Ctrl + B" } %>
+      <%= kui(:kbd) { "Ctrl + K" } %>
+    <% end %>
+    to open the command palette
+  </p>
+</div>

--- a/test/components/previews/kiso/kbd_preview/input_group.html.erb
+++ b/test/components/previews/kiso/kbd_preview/input_group.html.erb
@@ -1,0 +1,12 @@
+<div class="text-foreground flex w-full max-w-xs flex-col gap-6">
+  <%= kui(:input_group) do %>
+    <%= kui(:input_group, :addon) do %>
+      <%= kiso_icon("search", class: "size-4") %>
+    <% end %>
+    <%= kui(:input, placeholder: "Search...") %>
+    <%= kui(:input_group, :addon, align: :end) do %>
+      <%= kui(:kbd) { "⌘" } %>
+      <%= kui(:kbd) { "K" } %>
+    <% end %>
+  <% end %>
+</div>

--- a/test/components/previews/kiso/kbd_preview/playground.html.erb
+++ b/test/components/previews/kiso/kbd_preview/playground.html.erb
@@ -1,0 +1,3 @@
+<div class="text-foreground flex items-center justify-center p-8">
+  <%= kui(:kbd, size: size) { text } %>
+</div>

--- a/test/components/previews/kiso/kbd_preview/sizes.html.erb
+++ b/test/components/previews/kiso/kbd_preview/sizes.html.erb
@@ -1,0 +1,5 @@
+<div class="text-foreground flex items-center gap-4">
+  <%= kui(:kbd, size: :sm) { "⌘K" } %>
+  <%= kui(:kbd, size: :md) { "⌘K" } %>
+  <%= kui(:kbd, size: :lg) { "⌘K" } %>
+</div>


### PR DESCRIPTION
## Summary
- New `Kbd` component for displaying keyboard shortcuts inline
- `KbdGroup` sub-part for combining multiple keys
- 3 sizes (sm/md/lg), semantic `<kbd>` element, matches shadcn structure
- Lookbook previews: playground, demo, group, sizes, button, input group
- Docs page + navigation entry + skills reference
- Replaced hardcoded `<kbd>` elements in command dialog and input group previews

Closes #67

## Test plan
- [x] All 6 Kbd Lookbook previews render (200)
- [x] Modified previews (command/dialog, input_group/prefix_and_suffix) still render (200)
- [x] standardrb passes
- [x] rake test passes
- [ ] Visual review in Lookbook