### PR TITLE
feat: Set up oxlint and oxfmt for JS linting and formatting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+vendor/
+docs/
+node_modules/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ on:
   pull_request:
 
 jobs:
-  lint:
-    name: Lint
+  lint-ruby:
+    name: Lint Ruby
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -15,6 +15,18 @@ jobs:
           ruby-version: "3.4"
           bundler-cache: true
       - run: bundle exec standardrb
+
+  lint-js:
+    name: Lint & Format JS
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - run: npm ci
+      - run: npx oxlint --deny-warnings
+      - run: npx oxfmt --check .
 
   test:
     name: Test (Ruby ${{ matrix.ruby-version }})

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ Gemfile.lock
 /lookbook/config/master.key
 /lookbook/log/
 /lookbook/tmp/
+node_modules/
 .playwright-mcp/
 .claude/worktrees/

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": false,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "sortImports": {},
+  "sortTailwindcss": {},
+  "ignorePatterns": [
+    "vendor/**",
+    "node_modules/**",
+    "docs/**",
+    "project/**",
+    ".claude/**",
+    "skills/**",
+    "*.md",
+    "*.css"
+  ]
+}

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "categories": {
+    "correctness": "error",
+    "suspicious": "warn"
+  },
+  "rules": {
+    "no-unused-vars": ["error", { "args": "after-used" }],
+    "no-console": "warn"
+  },
+  "env": {
+    "browser": true,
+    "es2024": true
+  }
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["oxc.oxc-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.defaultFormatter": "oxc.oxc-vscode",
+  "editor.formatOnSave": true,
+  "oxc.lint.enable": true
+}

--- a/app/javascript/controllers/kiso/combobox_controller.js
+++ b/app/javascript/controllers/kiso/combobox_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
-import { positionBelow } from "./utils/positioning"
+
 import { highlightItem, wrapIndex } from "./utils/highlight"
+import { positionBelow } from "./utils/positioning"
 
 /**
  * Combobox autocomplete with keyboard navigation, filtering, and form integration.
@@ -46,7 +47,19 @@ import { highlightItem, wrapIndex } from "./utils/highlight"
  *   Detail: `{ value: string }` (single) or `{ value: string[] }` (multiple).
  */
 export default class extends Controller {
-  static targets = ["input", "content", "list", "item", "indicator", "empty", "hiddenInput", "trigger", "chips", "chip", "chipTemplate"]
+  static targets = [
+    "input",
+    "content",
+    "list",
+    "item",
+    "indicator",
+    "empty",
+    "hiddenInput",
+    "trigger",
+    "chips",
+    "chip",
+    "chipTemplate",
+  ]
   static values = { multiple: { type: Boolean, default: false } }
 
   connect() {
@@ -250,7 +263,9 @@ export default class extends Controller {
     this._addGlobalListeners()
 
     // Reset filter to show all items
-    this.itemTargets.forEach((item) => { item.hidden = false })
+    this.itemTargets.forEach((item) => {
+      item.hidden = false
+    })
     if (this.hasEmptyTarget) {
       this.emptyTarget.hidden = true
     }
@@ -259,7 +274,7 @@ export default class extends Controller {
     // Highlight the selected item (single mode) or first item
     if (!this.multipleValue) {
       const selectedIndex = this._visibleEnabledItems.findIndex(
-        (item) => item.getAttribute("aria-selected") === "true"
+        (item) => item.getAttribute("aria-selected") === "true",
       )
       this._highlightIndex(selectedIndex >= 0 ? selectedIndex : 0)
     } else {
@@ -496,9 +511,7 @@ export default class extends Controller {
    * @private
    */
   get _visibleEnabledItems() {
-    return this.itemTargets.filter(
-      (item) => !item.hidden && item.dataset.disabled !== "true"
-    )
+    return this.itemTargets.filter((item) => !item.hidden && item.dataset.disabled !== "true")
   }
 
   /**
@@ -562,7 +575,8 @@ export default class extends Controller {
     if (!this.hasContentTarget) return
 
     // Find the anchor — either the combobox-input wrapper, chips container, or the controller element
-    const anchor = this.element.querySelector("[data-slot='combobox-input']") ||
+    const anchor =
+      this.element.querySelector("[data-slot='combobox-input']") ||
       this.element.querySelector("[data-slot='combobox-chips']") ||
       this.element
 

--- a/app/javascript/controllers/kiso/command_controller.js
+++ b/app/javascript/controllers/kiso/command_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
-import { highlightItem, wrapIndex } from "./utils/highlight"
+
+import { wrapIndex } from "./utils/highlight"
 
 /**
  * Command palette with search filtering, keyboard navigation, and item selection.
@@ -212,9 +213,6 @@ export default class extends Controller {
    * @private
    */
   get _visibleEnabledItems() {
-    return this.itemTargets.filter(
-      (item) => !item.hidden && item.dataset.disabled !== "true"
-    )
+    return this.itemTargets.filter((item) => !item.hidden && item.dataset.disabled !== "true")
   }
-
 }

--- a/app/javascript/controllers/kiso/command_dialog_controller.js
+++ b/app/javascript/controllers/kiso/command_dialog_controller.js
@@ -17,7 +17,7 @@ import { Controller } from "@hotwired/stimulus"
  */
 export default class extends Controller {
   static values = {
-    shortcut: { type: String, default: "k" }
+    shortcut: { type: String, default: "k" },
   }
 
   connect() {

--- a/app/javascript/controllers/kiso/dropdown_menu_controller.js
+++ b/app/javascript/controllers/kiso/dropdown_menu_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
-import { positionBelow } from "./utils/positioning"
+
 import { highlightItem, wrapIndex } from "./utils/highlight"
+import { positionBelow } from "./utils/positioning"
 
 /**
  * Dropdown menu with keyboard navigation, sub-menus, checkbox items, and radio items.
@@ -45,7 +46,7 @@ export default class extends Controller {
     "radioItem",
     "sub",
     "subTrigger",
-    "subContent"
+    "subContent",
   ]
 
   connect() {
@@ -155,7 +156,7 @@ export default class extends Controller {
     }
 
     this.dispatch("checkbox-change", {
-      detail: { item, checked: newChecked }
+      detail: { item, checked: newChecked },
     })
   }
 
@@ -174,9 +175,7 @@ export default class extends Controller {
 
     if (group) {
       // Deselect all radio items in this group
-      const radioItems = group.querySelectorAll(
-        "[data-slot='dropdown-menu-radio-item']"
-      )
+      const radioItems = group.querySelectorAll("[data-slot='dropdown-menu-radio-item']")
       radioItems.forEach((radio) => {
         radio.setAttribute("aria-checked", "false")
         const indicator = radio.querySelector("[data-slot='dropdown-menu-item-indicator']")
@@ -206,9 +205,7 @@ export default class extends Controller {
     const sub = subTrigger.closest("[data-slot='dropdown-menu-sub']")
     if (!sub) return
 
-    const subContent = sub.querySelector(
-      "[data-slot='dropdown-menu-sub-content']"
-    )
+    const subContent = sub.querySelector("[data-slot='dropdown-menu-sub-content']")
     if (!subContent) return
 
     if (subContent.hidden) {
@@ -234,29 +231,21 @@ export default class extends Controller {
     const sub = subTrigger.closest("[data-slot='dropdown-menu-sub']")
     if (!sub) return
 
-    const subContent = sub.querySelector(
-      "[data-slot='dropdown-menu-sub-content']"
-    )
+    const subContent = sub.querySelector("[data-slot='dropdown-menu-sub-content']")
     if (!subContent || !subContent.hidden) return
 
     // Close any other open sub-menus at the same level
     const parent = sub.parentElement
     if (parent) {
-      parent
-        .querySelectorAll(":scope > [data-slot='dropdown-menu-sub']")
-        .forEach((otherSub) => {
-          if (otherSub !== sub) {
-            const otherContent = otherSub.querySelector(
-              "[data-slot='dropdown-menu-sub-content']"
-            )
-            const otherTrigger = otherSub.querySelector(
-              "[data-slot='dropdown-menu-sub-trigger']"
-            )
-            if (otherContent && !otherContent.hidden) {
-              this._closeSub(otherSub, otherTrigger, otherContent)
-            }
+      parent.querySelectorAll(":scope > [data-slot='dropdown-menu-sub']").forEach((otherSub) => {
+        if (otherSub !== sub) {
+          const otherContent = otherSub.querySelector("[data-slot='dropdown-menu-sub-content']")
+          const otherTrigger = otherSub.querySelector("[data-slot='dropdown-menu-sub-trigger']")
+          if (otherContent && !otherContent.hidden) {
+            this._closeSub(otherSub, otherTrigger, otherContent)
           }
-        })
+        }
+      })
     }
 
     this._openSub(sub, subTrigger, subContent)
@@ -341,17 +330,13 @@ export default class extends Controller {
     this._removeSubContentListeners(subContent)
 
     // Close nested sub-menus recursively
-    subContent
-      .querySelectorAll("[data-slot='dropdown-menu-sub-content']")
-      .forEach((nested) => {
-        nested.hidden = true
-        this._removeSubContentListeners(nested)
-      })
-    subContent
-      .querySelectorAll("[data-slot='dropdown-menu-sub-trigger']")
-      .forEach((nested) => {
-        nested.removeAttribute("data-state")
-      })
+    subContent.querySelectorAll("[data-slot='dropdown-menu-sub-content']").forEach((nested) => {
+      nested.hidden = true
+      this._removeSubContentListeners(nested)
+    })
+    subContent.querySelectorAll("[data-slot='dropdown-menu-sub-trigger']").forEach((nested) => {
+      nested.removeAttribute("data-state")
+    })
   }
 
   /**
@@ -400,10 +385,7 @@ export default class extends Controller {
       for (const child of el.children) {
         const slot = child.dataset?.slot
         // Skip hidden sub-content
-        if (
-          slot === "dropdown-menu-sub-content" &&
-          child.hidden
-        ) {
+        if (slot === "dropdown-menu-sub-content" && child.hidden) {
           continue
         }
         if (
@@ -502,7 +484,7 @@ export default class extends Controller {
       "[data-slot='dropdown-menu-item'], " +
         "[data-slot='dropdown-menu-checkbox-item'], " +
         "[data-slot='dropdown-menu-radio-item'], " +
-        "[data-slot='dropdown-menu-sub-trigger']"
+        "[data-slot='dropdown-menu-sub-trigger']",
     )
     if (!item || !this.element.contains(item)) return
     if (item.dataset.disabled === "true") return
@@ -513,29 +495,23 @@ export default class extends Controller {
     // When hovering a regular item, close open subs at the same level
     if (item.dataset.slot !== "dropdown-menu-sub-trigger") {
       const parentContainer = item.closest(
-        "[data-slot='dropdown-menu-content'], [data-slot='dropdown-menu-sub-content']"
+        "[data-slot='dropdown-menu-content'], [data-slot='dropdown-menu-sub-content']",
       )
       if (parentContainer) {
-        parentContainer
-          .querySelectorAll("[data-slot='dropdown-menu-sub']")
-          .forEach((sub) => {
-            // Only close subs whose nearest content ancestor is this container
-            if (
-              sub.closest(
-                "[data-slot='dropdown-menu-content'], [data-slot='dropdown-menu-sub-content']"
-              ) === parentContainer
-            ) {
-              const sc = sub.querySelector(
-                "[data-slot='dropdown-menu-sub-content']"
-              )
-              const st = sub.querySelector(
-                "[data-slot='dropdown-menu-sub-trigger']"
-              )
-              if (sc && !sc.hidden) {
-                this._closeSub(sub, st, sc)
-              }
+        parentContainer.querySelectorAll("[data-slot='dropdown-menu-sub']").forEach((sub) => {
+          // Only close subs whose nearest content ancestor is this container
+          if (
+            sub.closest(
+              "[data-slot='dropdown-menu-content'], [data-slot='dropdown-menu-sub-content']",
+            ) === parentContainer
+          ) {
+            const sc = sub.querySelector("[data-slot='dropdown-menu-sub-content']")
+            const st = sub.querySelector("[data-slot='dropdown-menu-sub-trigger']")
+            if (sc && !sc.hidden) {
+              this._closeSub(sub, st, sc)
             }
-          })
+          }
+        })
       }
     }
   }
@@ -571,9 +547,7 @@ export default class extends Controller {
     // Find the currently active sub-content (deepest open sub)
     let activeContainer = this.contentTarget
     const openSubs = Array.from(
-      this.element.querySelectorAll(
-        "[data-slot='dropdown-menu-sub-content']:not([hidden])"
-      )
+      this.element.querySelectorAll("[data-slot='dropdown-menu-sub-content']:not([hidden])"),
     )
     if (openSubs.length > 0) {
       activeContainer = openSubs[openSubs.length - 1]
@@ -582,9 +556,7 @@ export default class extends Controller {
     const items = this._allMenuItems(activeContainer)
 
     // Find current highlighted in active container
-    let currentIndex = items.findIndex((item) =>
-      item.hasAttribute("data-highlighted")
-    )
+    let currentIndex = items.findIndex((item) => item.hasAttribute("data-highlighted"))
 
     switch (event.key) {
       case "ArrowDown":
@@ -602,9 +574,7 @@ export default class extends Controller {
           const current = items[currentIndex]
           if (current.dataset.slot === "dropdown-menu-sub-trigger") {
             const sub = current.closest("[data-slot='dropdown-menu-sub']")
-            const subContent = sub?.querySelector(
-              "[data-slot='dropdown-menu-sub-content']"
-            )
+            const subContent = sub?.querySelector("[data-slot='dropdown-menu-sub-content']")
             if (sub && subContent && subContent.hidden) {
               this._openSub(sub, current, subContent)
               // Highlight first item in sub
@@ -621,12 +591,8 @@ export default class extends Controller {
         event.preventDefault()
         // Close the current sub-menu if we're in one
         if (activeContainer !== this.contentTarget) {
-          const sub = activeContainer.closest(
-            "[data-slot='dropdown-menu-sub']"
-          )
-          const subTrigger = sub?.querySelector(
-            "[data-slot='dropdown-menu-sub-trigger']"
-          )
+          const sub = activeContainer.closest("[data-slot='dropdown-menu-sub']")
+          const subTrigger = sub?.querySelector("[data-slot='dropdown-menu-sub-trigger']")
           if (sub && subTrigger) {
             this._closeSub(sub, subTrigger, activeContainer)
             this._clearAllHighlights()
@@ -647,12 +613,8 @@ export default class extends Controller {
         event.preventDefault()
         // If in a sub-menu, close just that sub
         if (activeContainer !== this.contentTarget) {
-          const sub = activeContainer.closest(
-            "[data-slot='dropdown-menu-sub']"
-          )
-          const subTrigger = sub?.querySelector(
-            "[data-slot='dropdown-menu-sub-trigger']"
-          )
+          const sub = activeContainer.closest("[data-slot='dropdown-menu-sub']")
+          const subTrigger = sub?.querySelector("[data-slot='dropdown-menu-sub-trigger']")
           if (sub && subTrigger) {
             this._closeSub(sub, subTrigger, activeContainer)
             this._clearAllHighlights()
@@ -721,5 +683,4 @@ export default class extends Controller {
     document.removeEventListener("click", this._handleOutsideClick, true)
     document.removeEventListener("keydown", this._handleKeydown)
   }
-
 }

--- a/app/javascript/controllers/kiso/index.js
+++ b/app/javascript/controllers/kiso/index.js
@@ -17,8 +17,17 @@ const KisoUi = {
     application.register("kiso--select", KisoSelectController)
     application.register("kiso--toggle", KisoToggleController)
     application.register("kiso--toggle-group", KisoToggleGroupController)
-  }
+  },
 }
 
 export default KisoUi
-export { KisoComboboxController, KisoCommandController, KisoCommandDialogController, KisoDropdownMenuController, KisoPopoverController, KisoSelectController, KisoToggleController, KisoToggleGroupController }
+export {
+  KisoComboboxController,
+  KisoCommandController,
+  KisoCommandDialogController,
+  KisoDropdownMenuController,
+  KisoPopoverController,
+  KisoSelectController,
+  KisoToggleController,
+  KisoToggleGroupController,
+}

--- a/app/javascript/controllers/kiso/popover_controller.js
+++ b/app/javascript/controllers/kiso/popover_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+
 import { FOCUSABLE_SELECTOR } from "./utils/focusable"
 import { positionBelow } from "./utils/positioning"
 
@@ -133,7 +134,7 @@ export default class extends Controller {
 
     positionBelow(reference, this.contentTarget, {
       align,
-      container: this.element
+      container: this.element,
     })
   }
 

--- a/app/javascript/controllers/kiso/select_controller.js
+++ b/app/javascript/controllers/kiso/select_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
-import { positionBelow } from "./utils/positioning"
+
 import { highlightItem, wrapIndex } from "./utils/highlight"
+import { positionBelow } from "./utils/positioning"
 
 /**
  * Custom select dropdown with keyboard navigation and form integration.
@@ -73,7 +74,7 @@ export default class extends Controller {
 
     // Highlight the currently selected item, or the first item
     const selectedIndex = this._enabledItems.findIndex(
-      (item) => item.getAttribute("aria-selected") === "true"
+      (item) => item.getAttribute("aria-selected") === "true",
     )
     this._highlightIndex(selectedIndex >= 0 ? selectedIndex : 0)
   }
@@ -145,7 +146,7 @@ export default class extends Controller {
     }
 
     // Update aria-selected on items and show/hide indicators
-    this.itemTargets.forEach((item, index) => {
+    this.itemTargets.forEach((item) => {
       const isSelected = item.dataset.value === value
       item.setAttribute("aria-selected", isSelected)
 
@@ -231,7 +232,8 @@ export default class extends Controller {
           const item = items[this._highlightedIndex]
           if (item.dataset.disabled !== "true") {
             const value = item.dataset.value
-            const text = item.querySelector("[data-slot='select-item-text']")?.textContent?.trim() || value
+            const text =
+              item.querySelector("[data-slot='select-item-text']")?.textContent?.trim() || value
             this._setValue(value, text)
             this.close()
           }

--- a/app/javascript/controllers/kiso/toggle_group_controller.js
+++ b/app/javascript/controllers/kiso/toggle_group_controller.js
@@ -27,7 +27,7 @@ export default class extends Controller {
   static values = {
     type: { type: String, default: "single" },
     variant: { type: String, default: "default" },
-    size: { type: String, default: "default" }
+    size: { type: String, default: "default" },
   }
 
   /**
@@ -121,8 +121,8 @@ export default class extends Controller {
 
     this.dispatch("change", {
       detail: {
-        value: this.typeValue === "single" ? selectedValues[0] || null : selectedValues
-      }
+        value: this.typeValue === "single" ? selectedValues[0] || null : selectedValues,
+      },
     })
   }
 }

--- a/app/javascript/controllers/kiso/utils/positioning.js
+++ b/app/javascript/controllers/kiso/utils/positioning.js
@@ -15,7 +15,11 @@
  * @param {"start"|"center"|"end"} [options.align="start"] - Horizontal alignment
  * @param {HTMLElement} [options.container] - Parent container for "end" alignment calculation
  */
-export function positionBelow(anchor, content, { gap = 4, align = "start", container = null } = {}) {
+export function positionBelow(
+  anchor,
+  content,
+  { gap = 4, align = "start", container = null } = {},
+) {
   const rect = anchor.getBoundingClientRect()
 
   content.style.position = "absolute"

--- a/lookbook/app/javascript/controllers/index.js
+++ b/lookbook/app/javascript/controllers/index.js
@@ -1,4 +1,4 @@
-import { application } from "controllers/application"
 import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
+import { application } from "controllers/application"
 
 eagerLoadControllersFrom("controllers", application)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,768 @@
+{
+  "name": "kiso-ui",
+  "version": "0.1.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kiso-ui",
+      "version": "0.1.1",
+      "license": "MIT",
+      "devDependencies": {
+        "oxfmt": "^0.35.0",
+        "oxlint": "^1.50.0"
+      },
+      "peerDependencies": {
+        "@hotwired/stimulus": ">=3.0.0"
+      }
+    },
+    "node_modules/@hotwired/stimulus": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@hotwired/stimulus/-/stimulus-3.2.2.tgz",
+      "integrity": "sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@oxfmt/binding-android-arm-eabi": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.35.0.tgz",
+      "integrity": "sha512-BaRKlM3DyG81y/xWTsE6gZiv89F/3pHe2BqX2H4JbiB8HNVlWWtplzgATAE5IDSdwChdeuWLDTQzJ92Lglw3ZA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-android-arm64": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.35.0.tgz",
+      "integrity": "sha512-/O+EbuAJYs6nde/anv+aID6uHsGQApyE9JtYBo/79KyU8e6RBN3DMbT0ix97y1SOnCglurmL2iZ+hlohjP2PnQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-arm64": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.35.0.tgz",
+      "integrity": "sha512-pGqRtqlNdn9d4VrmGUWVyQjkw79ryhI6je9y2jfqNUIZCfqceob+R97YYAoG7C5TFyt8ILdLVoN+L2vw/hSFyA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-x64": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.35.0.tgz",
+      "integrity": "sha512-8GmsDcSozTPjrCJeGpp+sCmS9+9V5yRrdEZ1p/sTWxPG5nYeAfSLuS0nuEYjXSO+CtdSbStIW6dxa+4NM58yRw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-freebsd-x64": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.35.0.tgz",
+      "integrity": "sha512-QyfKfTe0ytHpFKHAcHCGQEzN45QSqq1AHJOYYxQMgLM3KY4xu8OsXHpCnINjDsV4XGnQzczJDU9e04Zmd8XqIQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.35.0.tgz",
+      "integrity": "sha512-u+kv3JD6P3J38oOyUaiCqgY5TNESzBRZJ5lyZQ6c2czUW2v5SIN9E/KWWa9vxoc+P8AFXQFUVrdzGy1tK+nbPQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.35.0.tgz",
+      "integrity": "sha512-1NiZroCiV57I7Pf8kOH4XGR366kW5zir3VfSMBU2D0V14GpYjiYmPYFAoJboZvp8ACnZKUReWyMkNKSa5ad58A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-gnu": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.35.0.tgz",
+      "integrity": "sha512-7Q0Xeg7ZnW2nxnZ4R7aF6DEbCFls4skgHZg+I63XitpNvJCbVIU8MFOTZlvZGRsY9+rPgWPQGeUpLHlyx0wvMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-musl": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.35.0.tgz",
+      "integrity": "sha512-5Okqi+uhYFxwKz8hcnUftNNwdm8BCkf6GSCbcz9xJxYMm87k1E4p7PEmAAbhLTk7cjSdDre6TDL0pDzNX+Y22Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.35.0.tgz",
+      "integrity": "sha512-9k66pbZQXM/lBJWys3Xbc5yhl4JexyfqkEf/tvtq8976VIJnLAAL3M127xHA3ifYSqxdVHfVGTg84eiBHCGcNw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.35.0.tgz",
+      "integrity": "sha512-aUcY9ofKPtjO52idT6t0SAQvEF6ctjzUQa1lLp7GDsRpSBvuTrBQGeq0rYKz3gN8dMIQ7mtMdGD9tT4LhR8jAQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-musl": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.35.0.tgz",
+      "integrity": "sha512-C6yhY5Hvc2sGM+mCPek9ZLe5xRUOC/BvhAt2qIWFAeXMn4il04EYIjl3DsWiJr0xDMTJhvMOmD55xTRPlNp39w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-s390x-gnu": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.35.0.tgz",
+      "integrity": "sha512-RG2hlvOMK4OMZpO3mt8MpxLQ0AAezlFqhn5mI/g5YrVbPFyoCv9a34AAvbSJS501ocOxlFIRcKEuw5hFvddf9g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-gnu": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.35.0.tgz",
+      "integrity": "sha512-wzmh90Pwvqj9xOKHJjkQYBpydRkaXG77ZvDz+iFDRRQpnqIEqGm5gmim2s6vnZIkDGsvKCuTdtxm0GFmBjM1+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-musl": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.35.0.tgz",
+      "integrity": "sha512-+HCqYCJPCUy5I+b2cf+gUVaApfgtoQT3HdnSg/l7NIcLHOhKstlYaGyrFZLmUpQt4WkFbpGKZZayG6zjRU0KFA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-openharmony-arm64": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.35.0.tgz",
+      "integrity": "sha512-kFYmWfR9YL78XyO5ws+1dsxNvZoD973qfVMNFOS4e9bcHXGF7DvGC2tY5UDFwyMCeB33t3sDIuGONKggnVNSJA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-arm64-msvc": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.35.0.tgz",
+      "integrity": "sha512-uD/NGdM65eKNCDGyTGdO8e9n3IHX+wwuorBvEYrPJXhDXL9qz6gzddmXH8EN04ejUXUujlq4FsoSeCfbg0Y+Jg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-ia32-msvc": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.35.0.tgz",
+      "integrity": "sha512-oSRD2k8J2uxYDEKR2nAE/YTY9PobOEnhZgCmspHu0+yBQ665yH8lFErQVSTE7fcGJmJp/cC6322/gc8VFuQf7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-x64-msvc": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.35.0.tgz",
+      "integrity": "sha512-WCDJjlS95NboR0ugI2BEwzt1tYvRDorDRM9Lvctls1SLyKYuNRCyrPwp1urUPFBnwgBNn9p2/gnmo7gFMySRoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm-eabi": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.50.0.tgz",
+      "integrity": "sha512-G7MRGk/6NCe+L8ntonRdZP7IkBfEpiZ/he3buLK6JkLgMHgJShXZ+BeOwADmspXez7U7F7L1Anf4xLSkLHiGTg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm64": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.50.0.tgz",
+      "integrity": "sha512-GeSuMoJWCVpovJi/e3xDSNgjeR8WEZ6MCXL6EtPiCIM2NTzv7LbflARINTXTJy2oFBYyvdf/l2PwHzYo6EdXvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-arm64": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.50.0.tgz",
+      "integrity": "sha512-w3SY5YtxGnxCHPJ8Twl3KmS9oja1gERYk3AMoZ7Hv8P43ZtB6HVfs02TxvarxfL214Tm3uzvc2vn+DhtUNeKnw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-x64": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.50.0.tgz",
+      "integrity": "sha512-hNfogDqy7tvmllXKBSlHo6k5x7dhTUVOHbMSE15CCAcXzmqf5883aPvBYPOq9AE7DpDUQUZ1kVE22YbiGW+tuw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-freebsd-x64": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.50.0.tgz",
+      "integrity": "sha512-ykZevOWEyu0nsxolA911ucxpEv0ahw8jfEeGWOwwb/VPoE4xoexuTOAiPNlWZNJqANlJl7yp8OyzCtXTUAxotw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.50.0.tgz",
+      "integrity": "sha512-hif3iDk7vo5GGJ4OLCCZAf2vjnU9FztGw4L0MbQL0M2iY9LKFtDMMiQAHmkF0PQGQMVbTYtPdXCLKVgdkiqWXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-musleabihf": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.50.0.tgz",
+      "integrity": "sha512-dVp9iSssiGAnTNey2Ruf6xUaQhdnvcFOJyRWd/mu5o2jVbFK15E5fbWGeFRfmuobu5QXuROtFga44+7DOS3PLg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-gnu": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.50.0.tgz",
+      "integrity": "sha512-1cT7yz2HA910CKA9NkH1ZJo50vTtmND2fkoW1oyiSb0j6WvNtJ0Wx2zoySfXWc/c+7HFoqRK5AbEoL41LOn9oA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-musl": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.50.0.tgz",
+      "integrity": "sha512-++B3k/HEPFVlj89cOz8kWfQccMZB/aWL9AhsW7jPIkG++63Mpwb2cE9XOEsd0PATbIan78k2Gky+09uWM1d/gQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-ppc64-gnu": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.50.0.tgz",
+      "integrity": "sha512-Z9b/KpFMkx66w3gVBqjIC1AJBTZAGoI9+U+K5L4QM0CB/G0JSNC1es9b3Y0Vcrlvtdn8A+IQTkYjd/Q0uCSaZw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-gnu": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.50.0.tgz",
+      "integrity": "sha512-jvmuIw8wRSohsQlFNIST5uUwkEtEJmOQYr33bf/K2FrFPXHhM4KqGekI3ShYJemFS/gARVacQFgBzzJKCAyJjg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-musl": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.50.0.tgz",
+      "integrity": "sha512-x+UrN47oYNh90nmAAyql8eQaaRpHbDPu5guasDg10+OpszUQ3/1+1J6zFMmV4xfIEgTcUXG/oI5fxJhF4eWCNA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-s390x-gnu": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.50.0.tgz",
+      "integrity": "sha512-i/JLi2ljLUIVfekMj4ISmdt+Hn11wzYUdRRrkVUYsCWw7zAy5xV7X9iA+KMyM156LTFympa7s3oKBjuCLoTAUQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-gnu": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.50.0.tgz",
+      "integrity": "sha512-/C7brhn6c6UUPccgSPCcpLQXcp+xKIW/3sji/5VZ8/OItL3tQ2U7KalHz887UxxSQeEOmd1kY6lrpuwFnmNqOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-musl": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.50.0.tgz",
+      "integrity": "sha512-oDR1f+bGOYU8LfgtEW8XtotWGB63ghtcxk5Jm6IDTCk++rTA/IRMsjOid2iMd+1bW+nP9Mdsmcdc7VbPD3+iyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-openharmony-arm64": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.50.0.tgz",
+      "integrity": "sha512-4CmRGPp5UpvXyu4jjP9Tey/SrXDQLRvZXm4pb4vdZBxAzbFZkCyh0KyRy4txld/kZKTJlW4TO8N1JKrNEk+mWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-arm64-msvc": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.50.0.tgz",
+      "integrity": "sha512-Fq0M6vsGcFsSfeuWAACDhd5KJrO85ckbEfe1EGuBj+KPyJz7KeWte2fSFrFGmNKNXyhEMyx4tbgxiWRujBM2KQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-ia32-msvc": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.50.0.tgz",
+      "integrity": "sha512-qTdWR9KwY/vxJGhHVIZG2eBOhidOQvOwzDxnX+jhW/zIVacal1nAhR8GLkiywW8BIFDkQKXo/zOfT+/DY+ns/w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-x64-msvc": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.50.0.tgz",
+      "integrity": "sha512-682t7npLC4G2Ca+iNlI9fhAKTcFPYYXJjwoa88H4q+u5HHHlsnL/gHULapX3iqp+A8FIJbgdylL5KMYo2LaluQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/oxfmt": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.35.0.tgz",
+      "integrity": "sha512-QYeXWkP+aLt7utt5SLivNIk09glWx9QE235ODjgcEZ3sd1VMaUBSpLymh6ZRCA76gD2rMP4bXanUz/fx+nLM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinypool": "2.1.0"
+      },
+      "bin": {
+        "oxfmt": "bin/oxfmt"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxfmt/binding-android-arm-eabi": "0.35.0",
+        "@oxfmt/binding-android-arm64": "0.35.0",
+        "@oxfmt/binding-darwin-arm64": "0.35.0",
+        "@oxfmt/binding-darwin-x64": "0.35.0",
+        "@oxfmt/binding-freebsd-x64": "0.35.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.35.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.35.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.35.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.35.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.35.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.35.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.35.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.35.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.35.0",
+        "@oxfmt/binding-linux-x64-musl": "0.35.0",
+        "@oxfmt/binding-openharmony-arm64": "0.35.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.35.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.35.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.35.0"
+      }
+    },
+    "node_modules/oxlint": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.50.0.tgz",
+      "integrity": "sha512-iSJ4IZEICBma8cZX7kxIIz9PzsYLF2FaLAYN6RKu7VwRVKdu7RIgpP99bTZaGl//Yao7fsaGZLSEo5xBrI5ReQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "oxlint": "bin/oxlint"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxlint/binding-android-arm-eabi": "1.50.0",
+        "@oxlint/binding-android-arm64": "1.50.0",
+        "@oxlint/binding-darwin-arm64": "1.50.0",
+        "@oxlint/binding-darwin-x64": "1.50.0",
+        "@oxlint/binding-freebsd-x64": "1.50.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.50.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.50.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.50.0",
+        "@oxlint/binding-linux-arm64-musl": "1.50.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.50.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.50.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.50.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.50.0",
+        "@oxlint/binding-linux-x64-gnu": "1.50.0",
+        "@oxlint/binding-linux-x64-musl": "1.50.0",
+        "@oxlint/binding-openharmony-arm64": "1.50.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.50.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.50.0",
+        "@oxlint/binding-win32-x64-msvc": "1.50.0"
+      },
+      "peerDependencies": {
+        "oxlint-tsgolint": ">=0.14.1"
+      },
+      "peerDependenciesMeta": {
+        "oxlint-tsgolint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-2.1.0.tgz",
+      "integrity": "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,23 @@
   "name": "kiso-ui",
   "version": "0.1.1",
   "description": "Stimulus controllers for Kiso UI components",
+  "keywords": [
+    "components",
+    "rails",
+    "stimulus",
+    "ui"
+  ],
+  "license": "MIT",
+  "author": "Steve Clarke",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/steveclarke/kiso.git"
+  },
+  "files": [
+    "app/javascript/controllers/kiso",
+    "README.md",
+    "LICENSE"
+  ],
   "type": "module",
   "main": "app/javascript/controllers/kiso/index.js",
   "types": "app/javascript/controllers/kiso/index.d.ts",
@@ -9,24 +26,17 @@
     ".": "./app/javascript/controllers/kiso/index.js",
     "./controllers/*": "./app/javascript/controllers/kiso/*"
   },
-  "files": [
-    "app/javascript/controllers/kiso",
-    "README.md",
-    "LICENSE"
-  ],
-  "keywords": [
-    "stimulus",
-    "rails",
-    "ui",
-    "components"
-  ],
-  "author": "Steve Clarke",
-  "license": "MIT",
+  "scripts": {
+    "lint": "oxlint",
+    "lint:fix": "oxlint --fix",
+    "fmt": "oxfmt --write .",
+    "fmt:check": "oxfmt --check ."
+  },
+  "devDependencies": {
+    "oxfmt": "^0.35.0",
+    "oxlint": "^1.50.0"
+  },
   "peerDependencies": {
     "@hotwired/stimulus": ">=3.0.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/steveclarke/kiso.git"
   }
 }


### PR DESCRIPTION
## Summary
- Install oxlint + oxfmt as dev dependencies with npm scripts (`lint`, `lint:fix`, `fmt`, `fmt:check`)
- Add config files: `.oxlintrc.json`, `.oxfmtrc.json`, `.eslintignore`
- Add `.vscode/settings.json` (format-on-save) and `.vscode/extensions.json` (recommends Oxc extension)
- Add `lint-js` CI job to `.github/workflows/ci.yml` running both oxlint and oxfmt
- Auto-format all Stimulus controllers and fix two lint errors (unused import, unused parameter)

## Test plan
- [x] `npm run lint` passes clean
- [x] `npm run fmt:check` passes clean
- [x] `bundle exec rake test` still passes
- [ ] CI `lint-js` job passes on GitHub Actions