### PR TITLE
chore: wire up test/dummy as a real host app integration test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,7 @@ app/views/kiso/components/ ERB partials (rendered via kui() helper)
 app/assets/stylesheets/    Component CSS (thin — transitions/pseudo-states only)
 app/helpers/kiso/          kui(), kiso_prepare_options() helpers
 test/components/previews/  Lookbook preview classes + templates
+test/dummy/                Integration test app — real Rails host app using Kiso (bin/dummy → port 5000)
 lookbook/                  Lookbook dev app (bin/dev → port 4001)
 skills/kiso/               AI skill (component reference, theming guide)
 project/                   Architecture docs, design system, component vision docs
@@ -247,6 +248,9 @@ bin/dev restart docs          # Restart docs server
 bin/dev status                # Show running processes
 bin/dev stop                  # Stop all services
 bin/dev -f                    # Start in foreground (for debugging)
+bin/dummy                     # Start dummy integration app daemonized (port 5000)
+bin/dummy -f                  # Start dummy app in foreground
+bin/dummy stop                # Stop dummy app
 bundle exec rake test         # Run Ruby tests
 npm run test                  # Run all JS tests (unit + E2E)
 bundle exec standardrb --fix  # Lint & auto-format Ruby

--- a/bin/dummy
+++ b/bin/dummy
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+################################################################################
+# bin/dummy — Start the test/dummy Rails app
+################################################################################
+#
+# USAGE
+#   bin/dummy                  Start on port 3000 (daemonized)
+#   bin/dummy -f               Start in foreground
+#   bin/dummy stop             Stop the running instance
+#   DUMMY_PORT=3001 bin/dummy  Start on a custom port
+#
+################################################################################
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DUMMY_DIR="${SCRIPT_DIR}/../test/dummy"
+SOCKET="${DUMMY_DIR}/tmp/overmind.sock"
+PROCFILE="${DUMMY_DIR}/Procfile.dev"
+PORT="${DUMMY_PORT:-5000}"
+
+require_overmind() {
+  command -v overmind > /dev/null 2>&1 \
+    || { echo "Error: overmind is not installed." >&2; exit 1; }
+}
+
+is_running() {
+  [ -e "$SOCKET" ] && overmind status -s "$SOCKET" > /dev/null 2>&1
+}
+
+main() {
+  require_overmind
+  mkdir -p "${DUMMY_DIR}/tmp"
+
+  case "${1:-start}" in
+    start)
+      if is_running; then
+        echo "Dummy app is already running."
+        overmind status -s "$SOCKET"
+        echo ""
+        echo "  Dummy app → http://localhost:${PORT}"
+        return
+      fi
+      echo "Starting dummy app..."
+      cd "$DUMMY_DIR"
+      overmind start -f "$PROCFILE" -D -s "$SOCKET"
+      sleep 1
+      overmind status -s "$SOCKET"
+      echo ""
+      echo "  Dummy app → http://localhost:${PORT}"
+      ;;
+    -f)
+      cd "$DUMMY_DIR"
+      exec overmind start -f "$PROCFILE" -s "$SOCKET"
+      ;;
+    stop)
+      if ! is_running; then
+        [ -e "$SOCKET" ] && rm -f "$SOCKET"
+        echo "Dummy app is not running."
+        return
+      fi
+      overmind quit -s "$SOCKET" 2>/dev/null || rm -f "$SOCKET"
+      echo "Dummy app stopped."
+      ;;
+    *)
+      echo "Usage: bin/dummy [start|-f|stop]"
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/test/dummy/Procfile.dev
+++ b/test/dummy/Procfile.dev
@@ -1,2 +1,2 @@
-web: bin/rails server -p 4001
+web: bin/rails server -p ${DUMMY_PORT:-5000}
 css: bin/rails tailwindcss:watch

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -1,0 +1,2 @@
+class ApplicationController < ActionController::Base
+end

--- a/test/dummy/app/controllers/pages_controller.rb
+++ b/test/dummy/app/controllers/pages_controller.rb
@@ -1,0 +1,2 @@
+class PagesController < ApplicationController
+end

--- a/test/dummy/app/javascript/application.js
+++ b/test/dummy/app/javascript/application.js
@@ -1,0 +1,1 @@
+import "controllers"

--- a/test/dummy/app/javascript/controllers/application.js
+++ b/test/dummy/app/javascript/controllers/application.js
@@ -1,0 +1,7 @@
+import { Application } from "@hotwired/stimulus"
+
+const application = Application.start()
+application.debug = false
+window.Stimulus = application
+
+export { application }

--- a/test/dummy/app/javascript/controllers/index.js
+++ b/test/dummy/app/javascript/controllers/index.js
@@ -1,0 +1,4 @@
+import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
+import { application } from "controllers/application"
+
+eagerLoadControllersFrom("controllers", application)

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-    <title>Kiso Dummy</title>
+    <title><%= content_for(:title).presence || "Kiso Dummy" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
+    <%= javascript_importmap_tags %>
   </head>
-  <body>
+  <body class="bg-background text-foreground antialiased">
     <%= yield %>
   </body>
 </html>

--- a/test/dummy/app/views/pages/home.html.erb
+++ b/test/dummy/app/views/pages/home.html.erb
@@ -1,0 +1,156 @@
+<div class="max-w-5xl mx-auto px-6 py-12 space-y-12">
+
+  <div>
+    <h1 class="text-3xl font-bold tracking-tight">Kiso Dummy App</h1>
+    <p class="text-muted-foreground mt-1">Integration test — all components rendered from the Kiso engine.</p>
+  </div>
+
+  <%= kui(:separator) %>
+
+  <%# ── Badges ── %>
+  <section class="space-y-4">
+    <h2 class="text-xl font-semibold">Badges</h2>
+    <div class="flex flex-wrap gap-2">
+      <% %i[primary secondary success info warning error neutral].each do |color| %>
+        <%= kui(:badge, color: color, variant: :soft) { color.to_s.capitalize } %>
+      <% end %>
+    </div>
+    <div class="flex flex-wrap gap-2">
+      <% %i[solid outline soft subtle].each do |variant| %>
+        <%= kui(:badge, color: :primary, variant: variant) { variant.to_s } %>
+      <% end %>
+    </div>
+  </section>
+
+  <%= kui(:separator) %>
+
+  <%# ── Buttons ── %>
+  <section class="space-y-4">
+    <h2 class="text-xl font-semibold">Buttons</h2>
+    <div class="flex flex-wrap items-center gap-3">
+      <%= kui(:button, variant: :solid) { "Solid" } %>
+      <%= kui(:button, variant: :outline) { "Outline" } %>
+      <%= kui(:button, variant: :soft) { "Soft" } %>
+      <%= kui(:button, variant: :subtle) { "Subtle" } %>
+      <%= kui(:button, variant: :ghost) { "Ghost" } %>
+      <%= kui(:button, variant: :link) { "Link" } %>
+    </div>
+    <div class="flex flex-wrap items-center gap-3">
+      <% %i[sm md lg].each do |size| %>
+        <%= kui(:button, size: size) { size.to_s } %>
+      <% end %>
+      <%= kui(:button, color: :error, variant: :solid) { "Delete" } %>
+      <%= kui(:button, variant: :outline, disabled: true) { "Disabled" } %>
+    </div>
+  </section>
+
+  <%= kui(:separator) %>
+
+  <%# ── Alerts ── %>
+  <section class="space-y-4">
+    <h2 class="text-xl font-semibold">Alerts</h2>
+    <%= kui(:alert, color: :success, variant: :soft) do %>
+      <%= kui(:alert, :title) { "Success" } %>
+      <%= kui(:alert, :description) { "Your changes have been saved." } %>
+    <% end %>
+    <%= kui(:alert, color: :error, variant: :soft) do %>
+      <%= kui(:alert, :title) { "Error" } %>
+      <%= kui(:alert, :description) { "Something went wrong. Please try again." } %>
+    <% end %>
+    <%= kui(:alert, color: :info, variant: :outline) do %>
+      <%= kui(:alert, :title) { "Info" } %>
+      <%= kui(:alert, :description) { "A new version is available." } %>
+    <% end %>
+  </section>
+
+  <%= kui(:separator) %>
+
+  <%# ── Cards ── %>
+  <section class="space-y-4">
+    <h2 class="text-xl font-semibold">Cards</h2>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <% %i[outline soft subtle].each do |variant| %>
+        <%= kui(:card, variant: variant) do %>
+          <%= kui(:card, :header) do %>
+            <%= kui(:card, :title) { variant.to_s.capitalize } %>
+            <%= kui(:card, :description) { "Card variant: #{variant}" } %>
+          <% end %>
+          <%= kui(:card, :content) do %>
+            <p class="text-sm">Card content goes here.</p>
+          <% end %>
+          <%= kui(:card, :footer) do %>
+            <%= kui(:button, variant: :outline, size: :sm) { "Action" } %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+  </section>
+
+  <%= kui(:separator) %>
+
+  <%# ── Stats Cards ── %>
+  <section class="space-y-4">
+    <h2 class="text-xl font-semibold">Stats Cards</h2>
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      <%= kui(:stats_card) do %>
+        <%= kui(:stats_card, :header) do %>
+          <%= kui(:stats_card, :label) { "Total Revenue" } %>
+        <% end %>
+        <%= kui(:stats_card, :value) { "$45,231" } %>
+        <%= kui(:stats_card, :description) { "+20.1% from last month" } %>
+      <% end %>
+      <%= kui(:stats_card) do %>
+        <%= kui(:stats_card, :header) do %>
+          <%= kui(:stats_card, :label) { "Subscriptions" } %>
+        <% end %>
+        <%= kui(:stats_card, :value) { "+2,350" } %>
+        <%= kui(:stats_card, :description) { "+180 this week" } %>
+      <% end %>
+      <%= kui(:stats_card) do %>
+        <%= kui(:stats_card, :header) do %>
+          <%= kui(:stats_card, :label) { "Active Users" } %>
+        <% end %>
+        <%= kui(:stats_card, :value) { "1,247" } %>
+        <%= kui(:stats_card, :description) { "+12% from last month" } %>
+      <% end %>
+      <%= kui(:stats_card) do %>
+        <%= kui(:stats_card, :header) do %>
+          <%= kui(:stats_card, :label) { "Conversion" } %>
+        <% end %>
+        <%= kui(:stats_card, :value) { "4.6%" } %>
+        <%= kui(:stats_card, :description) { "+0.3% from last week" } %>
+      <% end %>
+    </div>
+  </section>
+
+  <%= kui(:separator) %>
+
+  <%# ── Form Inputs ── %>
+  <section class="space-y-4">
+    <h2 class="text-xl font-semibold">Form Inputs</h2>
+    <div class="max-w-sm space-y-4">
+      <%= kui(:field) do %>
+        <%= kui(:label, for: "email") { "Email" } %>
+        <%= kui(:input, type: :email, id: "email", placeholder: "you@example.com") %>
+      <% end %>
+      <%= kui(:field) do %>
+        <%= kui(:label, for: "bio") { "Bio" } %>
+        <%= kui(:textarea, id: "bio", placeholder: "Tell us about yourself...", rows: 3) %>
+      <% end %>
+    </div>
+  </section>
+
+  <%= kui(:separator) %>
+
+  <%# ── Toggle (Stimulus) ── %>
+  <section class="space-y-4">
+    <h2 class="text-xl font-semibold">Toggle (Stimulus)</h2>
+    <p class="text-sm text-muted-foreground">These use the Stimulus controller — verifies JS is loaded.</p>
+    <div class="flex gap-2">
+      <%= kui(:toggle) { "Bold" } %>
+      <%= kui(:toggle) { "Italic" } %>
+      <%= kui(:toggle, variant: :outline) { "Underline" } %>
+    </div>
+  </section>
+
+</div>

--- a/test/dummy/config/importmap.rb
+++ b/test/dummy/config/importmap.rb
@@ -1,0 +1,4 @@
+pin "application"
+pin "@hotwired/stimulus", to: "stimulus.min.js"
+pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
+pin_all_from "app/javascript/controllers", under: "controllers"

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -4,4 +4,6 @@ Rails.application.routes.draw do
   if defined?(Lookbook)
     mount Lookbook::Engine, at: "/lookbook"
   end
+
+  root "pages#home"
 end


### PR DESCRIPTION
## Summary

- Sets up `test/dummy` to work exactly like a real Rails app consuming Kiso — importmap, Stimulus, JS entry points, and a proper layout
- Adds `bin/dummy` (Overmind wrapper, port 5000) to start the dummy app with both Rails server and Tailwind watcher
- Adds a root kitchen-sink page (`pages#home`) demonstrating Badges, Buttons, Alerts, Cards, Stats Cards, Form Inputs, and Toggles — all rendered from the Kiso engine
- Documents `bin/dummy` and `test/dummy/` in CLAUDE.md

## Why

The dummy app was wired for CSS but had no JavaScript at all — no importmap, no Stimulus, no JS entry points. This means interactive components couldn't be tested in a real host app context.

This PR fixes that by adding exactly what a real host app would have after running `rails new` with importmap + Stimulus. Kiso's engine auto-appends its importmap config, so all 8 Stimulus controllers and 3 utility modules load automatically — proving the integration works end-to-end without any extra config.

This also serves as the sandbox for #83 (dashboard layout prototype).

## Test plan

- [ ] `bin/dummy` starts cleanly on port 5000
- [ ] `http://localhost:5000` renders the kitchen-sink page with all components styled
- [ ] Toggle buttons respond to clicks (confirms Stimulus controllers loaded)
- [ ] Dark mode works (semantic tokens on body)