### PR TITLE
feat: Calendar, Date Picker, and Input Date components

### DIFF
--- a/app/assets/tailwind/kiso/calendar.css
+++ b/app/assets/tailwind/kiso/calendar.css
@@ -1,0 +1,233 @@
+/* Calendar — styles for Cally web component Shadow DOM.
+
+   CRITICAL: Cally has its own --color-accent (default: black) and
+   --color-text-on-accent (default: white) CSS custom properties.
+   We MUST override these on the host element to prevent black
+   hover/today states. These are Cally's theming hooks, not Kiso tokens. */
+
+/* === Kiso calendar tokens ===
+   Cally internally uses --color-accent (default: black) which collides
+   with Kiso's --color-accent semantic token. We define our own prefixed
+   tokens on the calendar wrapper and reference ONLY these in ::part()
+   rules. This avoids the Shadow DOM variable resolution collision. */
+
+[data-slot="calendar"] {
+  --kiso-cal-hover-bg: var(--color-zinc-100);
+  --kiso-cal-hover-fg: var(--color-zinc-900);
+  --kiso-cal-today-bg: var(--color-zinc-100);
+  --kiso-cal-today-fg: var(--color-zinc-900);
+}
+
+.dark [data-slot="calendar"] {
+  --kiso-cal-hover-bg: var(--color-zinc-800);
+  --kiso-cal-hover-fg: var(--color-zinc-50);
+  --kiso-cal-today-bg: var(--color-zinc-800);
+  --kiso-cal-today-fg: var(--color-zinc-50);
+}
+
+/* Override Cally's --color-accent on calendar-month (where the :host
+   rule that sets it to black lives). This controls Cally's internal
+   hover and aria-pressed=true (selected/today) backgrounds. */
+[data-slot="calendar"] calendar-month {
+  --color-accent: var(--color-zinc-100);
+  --color-text-on-accent: var(--color-zinc-900);
+}
+
+.dark [data-slot="calendar"] calendar-month {
+  --color-accent: var(--color-zinc-800);
+  --color-text-on-accent: var(--color-zinc-50);
+}
+
+/* === Container === */
+
+[data-slot="calendar"]::part(container) {
+  padding: 0.75rem;
+}
+
+[data-slot="calendar"]::part(header) {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+/* Month/year heading — shadcn: text-sm font-medium */
+[data-slot="calendar"]::part(heading) {
+  font-size: 0.875rem;
+  font-weight: 500;
+  user-select: none;
+}
+
+/* === Navigation buttons — shadcn: ghost button, no border === */
+
+[data-slot="calendar"]::part(button) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius);
+  width: var(--cally-cell, 2rem);
+  height: var(--cally-cell, 2rem);
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--color-foreground);
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 150ms;
+}
+
+[data-slot="calendar"]::part(button):hover {
+  background-color: var(--kiso-cal-hover-bg);
+  color: var(--kiso-cal-hover-fg);
+}
+
+[data-slot="calendar"]::part(button disabled) {
+  cursor: default;
+  opacity: 0.5;
+}
+
+/* === Weekday headers — shadcn: text-[0.8rem] font-normal text-muted-foreground === */
+
+[data-slot="calendar"] calendar-month::part(head) {
+  color: var(--color-muted-foreground);
+  font-size: 0.8rem;
+  font-weight: 400;
+}
+
+[data-slot="calendar"] calendar-month::part(th) {
+  font-weight: 400;
+  width: var(--cally-cell, 2rem);
+  height: var(--cally-cell, 2rem);
+  user-select: none;
+}
+
+/* === Day cells — shadcn: ghost button, rounded-md, font-normal === */
+
+[data-slot="calendar"] calendar-month::part(day) {
+  border-radius: var(--radius);
+  font-size: 0.875rem;
+  font-weight: 400;
+  width: var(--cally-cell, 2rem);
+  height: var(--cally-cell, 2rem);
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  transition: background-color 150ms, color 150ms;
+}
+
+[data-slot="calendar"] calendar-month::part(day):hover {
+  background-color: var(--kiso-cal-hover-bg);
+  color: var(--kiso-cal-hover-fg);
+}
+
+/* === Today — shadcn: bg-accent text-accent-foreground rounded-md === */
+
+[data-slot="calendar"] calendar-month::part(today) {
+  background-color: var(--kiso-cal-today-bg);
+  color: var(--kiso-cal-today-fg);
+  font-weight: 500;
+}
+
+/* === Selected — solid variant (default) === */
+
+[data-slot="calendar"][data-variant="solid"] calendar-month::part(selected) {
+  background-color: var(--cally-color);
+  color: var(--cally-color-fg);
+  font-weight: 500;
+}
+
+[data-slot="calendar"][data-variant="solid"] calendar-month::part(selected):hover {
+  background-color: var(--cally-color);
+  color: var(--cally-color-fg);
+}
+
+/* Today + selected — selection styling wins */
+[data-slot="calendar"][data-variant="solid"] calendar-month::part(today selected) {
+  background-color: var(--cally-color);
+  color: var(--cally-color-fg);
+}
+
+/* === Selected — outline variant === */
+
+[data-slot="calendar"][data-variant="outline"] calendar-month::part(selected) {
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--cally-color) 50%, transparent);
+  color: var(--cally-color-fg);
+  background-color: transparent;
+}
+
+[data-slot="calendar"][data-variant="outline"] calendar-month::part(selected):hover {
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--cally-color) 50%, transparent);
+  color: var(--cally-color-fg);
+}
+
+/* === Selected — soft variant === */
+
+[data-slot="calendar"][data-variant="soft"] calendar-month::part(selected) {
+  background-color: color-mix(in srgb, var(--cally-color) 10%, transparent);
+  color: var(--cally-color-fg);
+  font-weight: 500;
+}
+
+[data-slot="calendar"][data-variant="soft"] calendar-month::part(selected):hover {
+  background-color: color-mix(in srgb, var(--cally-color) 20%, transparent);
+  color: var(--cally-color-fg);
+}
+
+/* === Selected — subtle variant === */
+
+[data-slot="calendar"][data-variant="subtle"] calendar-month::part(selected) {
+  background-color: color-mix(in srgb, var(--cally-color) 10%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--cally-color) 25%, transparent);
+  color: var(--cally-color-fg);
+  font-weight: 500;
+}
+
+[data-slot="calendar"][data-variant="subtle"] calendar-month::part(selected):hover {
+  background-color: color-mix(in srgb, var(--cally-color) 20%, transparent);
+  color: var(--cally-color-fg);
+}
+
+/* === Outside days — shadcn: text-muted-foreground === */
+
+[data-slot="calendar"] calendar-month::part(outside) {
+  color: var(--color-muted-foreground);
+  opacity: 0.5;
+}
+
+/* === Disabled / disallowed days — shadcn: text-muted-foreground opacity-50 === */
+
+[data-slot="calendar"] calendar-month::part(disallowed) {
+  color: var(--color-muted-foreground);
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* === Range selection — shadcn: rounded-l-md start, rounded-none middle, rounded-r-md end === */
+
+[data-slot="calendar"] calendar-month::part(range-start) {
+  background-color: var(--cally-color);
+  color: var(--cally-color-fg);
+  border-radius: var(--radius) 0 0 var(--radius);
+}
+
+[data-slot="calendar"] calendar-month::part(range-end) {
+  background-color: var(--cally-color);
+  color: var(--cally-color-fg);
+  border-radius: 0 var(--radius) var(--radius) 0;
+}
+
+[data-slot="calendar"] calendar-month::part(range-inner) {
+  background-color: var(--kiso-cal-hover-bg);
+  color: var(--kiso-cal-hover-fg);
+  border-radius: 0;
+}
+
+[data-slot="calendar"] calendar-month::part(range-start range-end) {
+  border-radius: var(--radius);
+}
+
+/* === Multi-month layout — shadcn: gap-4, flex-row on md === */
+
+[data-slot="calendar"]::part(months) {
+  display: flex;
+  gap: 1rem;
+}

--- a/app/assets/tailwind/kiso/engine.css
+++ b/app/assets/tailwind/kiso/engine.css
@@ -7,6 +7,7 @@
 @import "./radio-group.css";
 @import "./color-mode.css";
 @import "./dashboard.css";
+@import "./calendar.css";
 
 /* Scan Kiso's own files so host apps don't need to know the gem's internals.
    Paths are relative to THIS file (app/assets/tailwind/kiso/engine.css).

--- a/app/javascript/controllers/kiso/calendar_controller.js
+++ b/app/javascript/controllers/kiso/calendar_controller.js
@@ -1,0 +1,54 @@
+import { Controller } from "@hotwired/stimulus"
+import "cally"
+
+/**
+ * Calendar controller — initializes Cally web component theming by setting
+ * CSS custom properties that Cally's Shadow DOM reads internally.
+ *
+ * Cally's `<calendar-month>` declares `--color-accent: black` in its
+ * `:host` rule. External CSS cannot override `:host`-declared custom
+ * properties due to Shadow DOM encapsulation. This controller bridges
+ * Kiso's semantic tokens into Cally by reading the computed values
+ * from the wrapper and applying them as inline styles on each
+ * `<calendar-month>` element.
+ *
+ * @example
+ *   <div data-controller="kiso--calendar" data-slot="calendar">
+ *     <calendar-date>
+ *       <calendar-month></calendar-month>
+ *     </calendar-date>
+ *   </div>
+ *
+ * @property {HTMLElement[]} monthTargets - The calendar-month elements
+ */
+export default class extends Controller {
+  connect() {
+    this._applyTheme()
+    this._observer = new MutationObserver(() => this._applyTheme())
+    this._observer.observe(this.element, { childList: true, subtree: true })
+  }
+
+  disconnect() {
+    this._observer?.disconnect()
+  }
+
+  /**
+   * Reads Kiso's calendar tokens from the wrapper element and applies
+   * them as inline styles on each calendar-month element.
+   *
+   * @private
+   */
+  _applyTheme() {
+    const style = getComputedStyle(this.element)
+    const hoverBg = style.getPropertyValue("--kiso-cal-hover-bg").trim()
+    const hoverFg = style.getPropertyValue("--kiso-cal-hover-fg").trim()
+    const callyColor = style.getPropertyValue("--cally-color").trim()
+    const callyColorFg = style.getPropertyValue("--cally-color-fg").trim()
+
+    this.element.querySelectorAll("calendar-month").forEach((month) => {
+      // Override Cally's :host --color-accent (default: black)
+      if (hoverBg) month.style.setProperty("--color-accent", hoverBg)
+      if (hoverFg) month.style.setProperty("--color-text-on-accent", hoverFg)
+    })
+  }
+}

--- a/app/javascript/controllers/kiso/date_picker_controller.js
+++ b/app/javascript/controllers/kiso/date_picker_controller.js
@@ -1,0 +1,160 @@
+import { Controller } from "@hotwired/stimulus"
+import { startPositioning } from "kiso-ui/utils/positioning"
+import "cally"
+
+/**
+ * Date picker controller — wires a trigger button, native popover, and Cally
+ * calendar web component together. Syncs the selected date to a hidden input
+ * for form submission and formats the display using Intl.DateTimeFormat.
+ *
+ * Uses the native Popover API (`[popover]` + `popovertarget`) for open/close
+ * and Floating UI for positioning below the trigger.
+ *
+ * Attaches a change listener directly on the `<calendar-date>` or
+ * `<calendar-range>` element inside the popover, since Cally dispatches
+ * its `change` event with `bubbles: false`.
+ *
+ * @example
+ *   <div data-controller="kiso--date-picker" data-slot="date-picker"
+ *        data-kiso--date-picker-format-value="long">
+ *     <input type="hidden" name="date" data-kiso--date-picker-target="input">
+ *     <button type="button" popovertarget="dp-abc123"
+ *             data-kiso--date-picker-target="trigger">
+ *       <span data-kiso--date-picker-target="display">Pick a date</span>
+ *     </button>
+ *     <div id="dp-abc123" popover data-kiso--date-picker-target="popover">
+ *       <calendar-date>
+ *         <calendar-month></calendar-month>
+ *       </calendar-date>
+ *     </div>
+ *   </div>
+ *
+ * @property {HTMLInputElement} inputTarget - Hidden input for form submission (ISO 8601)
+ * @property {HTMLElement} triggerTarget - Button that opens the popover
+ * @property {HTMLElement} displayTarget - Span showing the formatted date
+ * @property {HTMLElement} popoverTarget - The popover container
+ *
+ * @fires change - Dispatched on the controller element when a date is selected
+ */
+export default class extends Controller {
+  static targets = ["input", "trigger", "display", "popover"]
+  static values = {
+    format: { type: String, default: "long" },
+    locale: String,
+  }
+
+  connect() {
+    this._handleToggle = this._handleToggle.bind(this)
+    this._handleChange = this._handleChange.bind(this)
+
+    this.popoverTarget.addEventListener("toggle", this._handleToggle)
+    this._attachCalendarListener()
+  }
+
+  disconnect() {
+    this._cleanupPosition?.()
+    this.popoverTarget.removeEventListener("toggle", this._handleToggle)
+    this._callyEl?.removeEventListener("change", this._handleChange)
+  }
+
+  /**
+   * Finds the Cally element inside the popover and attaches a change listener.
+   * Waits for the custom element to be defined if it hasn't upgraded yet.
+   *
+   * @private
+   */
+  _attachCalendarListener() {
+    const callyEl = this.popoverTarget.querySelector("calendar-date, calendar-range")
+    if (!callyEl) return
+
+    this._callyEl = callyEl
+    const tagName = callyEl.tagName.toLowerCase()
+
+    customElements.whenDefined(tagName).then(() => {
+      callyEl.addEventListener("change", this._handleChange)
+    })
+  }
+
+  /**
+   * Handles date selection from the Cally calendar's change event.
+   * Updates the display text, hidden input value, and closes the popover.
+   *
+   * @param {Event} event - The change event from calendar-date
+   * @private
+   */
+  _handleChange(event) {
+    const value = event.target.value
+    if (!value) return
+
+    this._updateDisplay(value)
+    this.inputTarget.value = value
+    this.popoverTarget.hidePopover()
+
+    this.dispatch("change", { detail: { value } })
+  }
+
+  /**
+   * Handles the popover toggle event to start/stop Floating UI positioning.
+   *
+   * @param {ToggleEvent} event
+   * @private
+   */
+  _handleToggle(event) {
+    if (event.newState === "open") {
+      this._startPositioning()
+    } else {
+      this._cleanupPosition?.()
+      this._cleanupPosition = null
+    }
+  }
+
+  /**
+   * Positions the popover below the trigger using Floating UI.
+   *
+   * @private
+   */
+  _startPositioning() {
+    // Native [popover] renders in the top-layer with default inset/margin.
+    // Reset these so Floating UI can position it with fixed strategy.
+    this.popoverTarget.style.inset = "unset"
+
+    this._cleanupPosition = startPositioning(this.triggerTarget, this.popoverTarget, {
+      placement: "bottom-start",
+      strategy: "fixed",
+    })
+  }
+
+  /**
+   * Formats and displays the selected date using Intl.DateTimeFormat.
+   *
+   * @param {string} isoDate - ISO 8601 date string (YYYY-MM-DD)
+   * @private
+   */
+  _updateDisplay(isoDate) {
+    const date = new Date(isoDate + "T00:00:00")
+    const options = this._dateFormatOptions()
+    const locale = this.hasLocaleValue ? this.localeValue : undefined
+
+    this.displayTarget.textContent = new Intl.DateTimeFormat(locale, options).format(date)
+    this.displayTarget.classList.remove("text-muted-foreground")
+  }
+
+  /**
+   * Returns Intl.DateTimeFormat options based on the format value.
+   *
+   * @returns {Intl.DateTimeFormatOptions}
+   * @private
+   */
+  _dateFormatOptions() {
+    switch (this.formatValue) {
+      case "short":
+        return { month: "numeric", day: "numeric", year: "numeric" }
+      case "medium":
+        return { month: "short", day: "numeric", year: "numeric" }
+      case "long":
+        return { month: "long", day: "numeric", year: "numeric" }
+      default:
+        return { month: "long", day: "numeric", year: "numeric" }
+    }
+  }
+}

--- a/app/javascript/controllers/kiso/input_date_controller.js
+++ b/app/javascript/controllers/kiso/input_date_controller.js
@@ -1,0 +1,309 @@
+import { Controller } from "@hotwired/stimulus"
+
+/**
+ * Segmented date input controller — renders individual day, month, and year
+ * segments that respond to keyboard input for precise date entry.
+ *
+ * Each segment is a focusable `<span>` element that supports:
+ * - **Arrow keys** — increment/decrement the segment value
+ * - **Number typing** — type-ahead with auto-advance (e.g., typing "03" sets month)
+ * - **Tab / Shift+Tab** — navigate between segments
+ * - **Backspace** — clear the segment back to placeholder
+ *
+ * Syncs the combined value to a hidden `<input>` for form submission in
+ * ISO 8601 format (YYYY-MM-DD).
+ *
+ * @example
+ *   <div data-controller="kiso--input-date" data-slot="input-date">
+ *     <input type="hidden" name="date" data-kiso--input-date-target="input">
+ *     <span data-kiso--input-date-target="segment" data-segment="month"
+ *           tabindex="0" role="spinbutton" aria-label="Month">MM</span>
+ *     <span data-slot="input-date-separator">/</span>
+ *     <span data-kiso--input-date-target="segment" data-segment="day"
+ *           tabindex="0" role="spinbutton" aria-label="Day">DD</span>
+ *     <span data-slot="input-date-separator">/</span>
+ *     <span data-kiso--input-date-target="segment" data-segment="year"
+ *           tabindex="0" role="spinbutton" aria-label="Year">YYYY</span>
+ *   </div>
+ *
+ * @property {HTMLInputElement} inputTarget - Hidden input for form submission
+ * @property {HTMLElement[]} segmentTargets - The editable segment spans
+ *
+ * @fires change - Dispatched when a complete valid date is entered
+ */
+export default class extends Controller {
+  static targets = ["input", "segment"]
+  static values = {
+    value: String,
+    min: String,
+    max: String,
+  }
+
+  /** @type {{ month: number|null, day: number|null, year: number|null }} */
+  _segments = { month: null, day: null, year: null }
+
+  /** @type {string} */
+  _typeBuffer = ""
+
+  /** @type {number|null} */
+  _typeTimeout = null
+
+  connect() {
+    if (this.hasValueValue && this.valueValue) {
+      this._parseValue(this.valueValue)
+    }
+    this._render()
+  }
+
+  /**
+   * Handles keydown events on segment elements.
+   * Dispatched via `data-action="keydown->kiso--input-date#keydown"`.
+   *
+   * @param {KeyboardEvent} event
+   */
+  keydown(event) {
+    const segment = event.currentTarget
+    const type = segment.dataset.segment
+
+    switch (event.key) {
+      case "ArrowUp":
+        event.preventDefault()
+        this._increment(type, 1)
+        break
+      case "ArrowDown":
+        event.preventDefault()
+        this._increment(type, -1)
+        break
+      case "ArrowRight":
+        event.preventDefault()
+        this._focusNext(segment)
+        break
+      case "ArrowLeft":
+        event.preventDefault()
+        this._focusPrev(segment)
+        break
+      case "Backspace":
+      case "Delete":
+        event.preventDefault()
+        this._clearSegment(type)
+        break
+      default:
+        if (event.key >= "0" && event.key <= "9") {
+          event.preventDefault()
+          this._typeDigit(type, event.key)
+        }
+    }
+  }
+
+  /**
+   * Parses an ISO date string into segment values.
+   *
+   * @param {string} iso - ISO 8601 date string (YYYY-MM-DD)
+   * @private
+   */
+  _parseValue(iso) {
+    const [year, month, day] = iso.split("-").map(Number)
+    if (year && month && day) {
+      this._segments = { year, month, day }
+    }
+  }
+
+  /**
+   * Increments or decrements a segment value, wrapping at boundaries.
+   *
+   * @param {string} type - "month", "day", or "year"
+   * @param {number} delta - 1 or -1
+   * @private
+   */
+  _increment(type, delta) {
+    const { min, max } = this._segmentRange(type)
+    let val = this._segments[type]
+
+    if (val === null) {
+      val = delta > 0 ? min : max
+    } else {
+      val += delta
+      if (val > max) val = min
+      if (val < min) val = max
+    }
+
+    this._segments[type] = val
+    this._render()
+    this._syncInput()
+  }
+
+  /**
+   * Handles digit typing with type-ahead and auto-advance.
+   *
+   * @param {string} type - "month", "day", or "year"
+   * @param {string} digit - Single digit character "0"-"9"
+   * @private
+   */
+  _typeDigit(type, digit) {
+    clearTimeout(this._typeTimeout)
+    this._typeBuffer += digit
+
+    const { min, max, digits } = this._segmentRange(type)
+    const num = parseInt(this._typeBuffer, 10)
+
+    if (this._typeBuffer.length >= digits) {
+      // Full number entered — clamp, set, and advance
+      this._segments[type] = Math.max(min, Math.min(max, num))
+      this._typeBuffer = ""
+      this._render()
+      this._syncInput()
+      this._focusNextFromType(type)
+    } else if (num > max / 10) {
+      // Single digit that can't form a valid prefix — set and advance
+      this._segments[type] = Math.max(min, Math.min(max, num))
+      this._typeBuffer = ""
+      this._render()
+      this._syncInput()
+      this._focusNextFromType(type)
+    } else {
+      // Partial entry — wait for more digits
+      this._segments[type] = num || null
+      this._render()
+      this._typeTimeout = setTimeout(() => {
+        if (this._typeBuffer) {
+          this._segments[type] = Math.max(min, Math.min(max, parseInt(this._typeBuffer, 10)))
+          this._typeBuffer = ""
+          this._render()
+          this._syncInput()
+        }
+      }, 800)
+    }
+  }
+
+  /**
+   * Clears a segment back to its placeholder.
+   *
+   * @param {string} type
+   * @private
+   */
+  _clearSegment(type) {
+    this._segments[type] = null
+    this._typeBuffer = ""
+    this._render()
+    this._syncInput()
+  }
+
+  /**
+   * Returns the valid range and digit count for a segment type.
+   *
+   * @param {string} type
+   * @returns {{ min: number, max: number, digits: number }}
+   * @private
+   */
+  _segmentRange(type) {
+    switch (type) {
+      case "month":
+        return { min: 1, max: 12, digits: 2 }
+      case "day":
+        return { min: 1, max: this._daysInMonth(), digits: 2 }
+      case "year":
+        return { min: 1900, max: 2099, digits: 4 }
+      default:
+        return { min: 0, max: 99, digits: 2 }
+    }
+  }
+
+  /**
+   * Returns the number of days in the currently selected month/year.
+   *
+   * @returns {number}
+   * @private
+   */
+  _daysInMonth() {
+    const { month, year } = this._segments
+    if (!month) return 31
+    return new Date(year || 2026, month, 0).getDate()
+  }
+
+  /**
+   * Renders all segment displays based on current values.
+   *
+   * @private
+   */
+  _render() {
+    for (const el of this.segmentTargets) {
+      const type = el.dataset.segment
+      const val = this._segments[type]
+      const { digits } = this._segmentRange(type)
+
+      if (val === null) {
+        el.textContent = type === "year" ? "YYYY" : type === "month" ? "MM" : "DD"
+        el.setAttribute("data-placeholder", "")
+        el.removeAttribute("aria-valuenow")
+      } else {
+        el.textContent = String(val).padStart(digits, "0")
+        el.removeAttribute("data-placeholder")
+        el.setAttribute("aria-valuenow", val)
+      }
+
+      const { min, max } = this._segmentRange(type)
+      el.setAttribute("aria-valuemin", min)
+      el.setAttribute("aria-valuemax", max)
+    }
+  }
+
+  /**
+   * Syncs the combined segment values to the hidden input.
+   * Only sets a value when all three segments are filled.
+   *
+   * @private
+   */
+  _syncInput() {
+    const { year, month, day } = this._segments
+
+    if (year !== null && month !== null && day !== null) {
+      const iso = `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`
+      this.inputTarget.value = iso
+      this.dispatch("change", { detail: { value: iso } })
+    } else {
+      this.inputTarget.value = ""
+    }
+  }
+
+  /**
+   * Focuses the next segment element.
+   *
+   * @param {HTMLElement} current
+   * @private
+   */
+  _focusNext(current) {
+    const idx = this.segmentTargets.indexOf(current)
+    if (idx < this.segmentTargets.length - 1) {
+      this.segmentTargets[idx + 1].focus()
+    }
+  }
+
+  /**
+   * Focuses the previous segment element.
+   *
+   * @param {HTMLElement} current
+   * @private
+   */
+  _focusPrev(current) {
+    const idx = this.segmentTargets.indexOf(current)
+    if (idx > 0) {
+      this.segmentTargets[idx - 1].focus()
+    }
+  }
+
+  /**
+   * Focuses the next segment after type-ahead completes.
+   *
+   * @param {string} type - Current segment type
+   * @private
+   */
+  _focusNextFromType(type) {
+    const order = ["month", "day", "year"]
+    const idx = order.indexOf(type)
+    if (idx < order.length - 1) {
+      const nextType = order[idx + 1]
+      const nextEl = this.segmentTargets.find((el) => el.dataset.segment === nextType)
+      nextEl?.focus()
+    }
+  }
+}

--- a/app/javascript/kiso/vendor/cally.js
+++ b/app/javascript/kiso/vendor/cally.js
@@ -1,0 +1,1303 @@
+class le {
+  /**
+   * @type {T}
+   */
+  #t;
+  #e = /* @__PURE__ */ new Set();
+  /**
+   * @param {T} current
+   */
+  constructor(t) {
+    this.#t = t;
+  }
+  /**
+   * @return {T}
+   */
+  get current() {
+    return this.#t;
+  }
+  /**
+   * @param {T} value
+   */
+  set current(t) {
+    this.#t != t && (this.#t = t, this.#e.forEach((n) => n(t)));
+  }
+  /**
+   * @type {import("hooks").Ref["on"]}
+   */
+  on(t) {
+    return this.#e.add(t), () => this.#e.delete(t);
+  }
+}
+const Rt = (e) => new le(e), st = Symbol.for("atomico.hooks");
+globalThis[st] = globalThis[st] || {};
+let A = globalThis[st];
+const ue = Symbol.for("Atomico.suspense"), Yt = Symbol.for("Atomico.effect"), fe = Symbol.for("Atomico.layoutEffect"), Ft = Symbol.for("Atomico.insertionEffect"), R = (e, t, n) => {
+  const { i: s, hooks: o } = A.c, r = o[s] = o[s] || {};
+  return r.value = e(r.value), r.effect = t, r.tag = n, A.c.i++, o[s].value;
+}, It = (e) => R((t = Rt(e)) => t), W = () => R((e = Rt(A.c.host)) => e), Lt = () => A.c.update, de = (e, t, n = 0) => {
+  let s = {}, o = !1;
+  const r = () => o, a = (l, c) => {
+    for (const d in s) {
+      const i = s[d];
+      i.effect && i.tag === l && (i.value = i.effect(i.value, c));
+    }
+  };
+  return { load: (l) => {
+    A.c = { host: t, hooks: s, update: e, i: 0, id: n };
+    let c;
+    try {
+      o = !1, c = l();
+    } catch (d) {
+      if (d !== ue) throw d;
+      o = !0;
+    } finally {
+      A.c = null;
+    }
+    return c;
+  }, cleanEffects: (l) => (a(Ft, l), () => (a(fe, l), () => {
+    a(Yt, l);
+  })), isSuspense: r };
+}, x = Symbol.for;
+function xt(e, t) {
+  const n = e.length;
+  if (n !== t.length) return !1;
+  for (let s = 0; s < n; s++) {
+    let o = e[s], r = t[s];
+    if (o !== r) return !1;
+  }
+  return !0;
+}
+const M = (e) => typeof e == "function", F = (e) => typeof e == "object", { isArray: he } = Array, ot = (e, t) => (t ? e instanceof HTMLStyleElement : !0) && "hydrate" in (e?.dataset || {});
+function _t(e, t) {
+  let n;
+  const s = (o) => {
+    let { length: r } = o;
+    for (let a = 0; a < r; a++) {
+      const u = o[a];
+      if (u && Array.isArray(u))
+        s(u);
+      else {
+        const f = typeof u;
+        if (u == null || f === "function" || f === "boolean")
+          continue;
+        f === "string" || f === "number" ? (n == null && (n = ""), n += u) : (n != null && (t(n), n = null), t(u));
+      }
+    }
+  };
+  s(e), n != null && t(n);
+}
+const jt = (e, t, n) => (e.addEventListener(t, n), () => e.removeEventListener(t, n));
+class Bt {
+  /**
+   *
+   * @param {HTMLElement} target
+   * @param {string} message
+   * @param {string} value
+   */
+  constructor(t, n, s) {
+    this.message = n, this.target = t, this.value = s;
+  }
+}
+class qt extends Bt {
+}
+class me extends Bt {
+}
+const z = "Custom", ye = null, pe = { true: 1, "": 1, 1: 1 };
+function ge(e, t, n, s, o) {
+  const {
+    type: r,
+    reflect: a,
+    event: u,
+    value: f,
+    attr: l = be(t)
+  } = n?.name != z && F(n) && n != ye ? n : { type: n }, c = r?.name === z && r.map, d = f != null ? r == Function || !M(f) ? () => f : f : null;
+  Object.defineProperty(e, t, {
+    configurable: !0,
+    /**
+     * @this {import("dom").AtomicoThisInternal}
+     * @param {any} newValue
+     */
+    set(i) {
+      const m = this[t];
+      d && r != Boolean && i == null && (i = d());
+      const { error: g, value: b } = (c ? Te : Ee)(
+        r,
+        i
+      );
+      if (g && b != null)
+        throw new qt(
+          this,
+          `The value defined for prop '${t}' must be of type '${r.name}'`,
+          b
+        );
+      m != b && (this._props[t] = b ?? void 0, this.update(), u && zt(this, u), this.updated.then(() => {
+        a && (this._ignoreAttr = l, De(this, r, l, this[t]), this._ignoreAttr = null);
+      }));
+    },
+    /**
+     * @this {import("dom").AtomicoThisInternal}
+     */
+    get() {
+      return this._props[t];
+    }
+  }), d && (o[t] = d()), s[l] = { prop: t, type: r };
+}
+const zt = (e, { type: t, base: n = CustomEvent, ...s }) => e.dispatchEvent(new n(t, s)), be = (e) => e.replace(/([A-Z])/g, "-$1").toLowerCase(), De = (e, t, n, s) => s == null || t == Boolean && !s ? e.removeAttribute(n) : e.setAttribute(
+  n,
+  t?.name === z && t?.serialize ? t?.serialize(s) : F(s) ? JSON.stringify(s) : t == Boolean ? "" : s
+), Ce = (e, t) => e == Boolean ? !!pe[t] : e == Number ? Number(t) : e == String ? t : e == Array || e == Object ? JSON.parse(t) : e.name == z ? t : (
+  // TODO: If when defining reflect the prop can also be of type string?
+  new e(t)
+), Te = ({ map: e }, t) => {
+  try {
+    return { value: e(t), error: !1 };
+  } catch {
+    return { value: t, error: !0 };
+  }
+}, Ee = (e, t) => e == null || t == null ? { value: t, error: !1 } : e != String && t === "" ? { value: void 0, error: !1 } : e == Object || e == Array || e == Symbol ? {
+  value: t,
+  error: {}.toString.call(t) !== `[object ${e.name}]`
+} : t instanceof e ? {
+  value: t,
+  error: e == Number && Number.isNaN(t.valueOf())
+} : e == String || e == Number || e == Boolean ? {
+  value: t,
+  error: e == Number ? typeof t != "number" ? !0 : Number.isNaN(t) : e == String ? typeof t != "string" : typeof t != "boolean"
+} : { value: t, error: !0 };
+let ve = 0;
+const we = (e) => {
+  const t = (e?.dataset || {})?.hydrate || "";
+  return t || "c" + ve++;
+}, k = (e, t = HTMLElement) => {
+  const n = {}, s = {}, o = "prototype" in t && t.prototype instanceof Element, r = o ? t : "base" in t ? t.base : HTMLElement, { props: a, styles: u } = o ? e : t;
+  class f extends r {
+    constructor() {
+      super(), this._setup(), this._render = () => e({ ...this._props });
+      for (const c in s) this[c] = s[c];
+    }
+    /**
+     * @returns {import("core").Sheets[]}
+     */
+    static get styles() {
+      return [super.styles, u];
+    }
+    async _setup() {
+      if (this._props) return;
+      this._props = {};
+      let c, d;
+      this.mounted = new Promise(
+        (y) => this.mount = () => {
+          y(), c != this.parentNode && (d != c ? this.unmounted.then(this.update) : this.update()), c = this.parentNode;
+        }
+      ), this.unmounted = new Promise(
+        (y) => this.unmount = () => {
+          y(), (c != this.parentNode || !this.isConnected) && (i.cleanEffects(!0)()(), d = this.parentNode, c = null);
+        }
+      ), this.symbolId = this.symbolId || Symbol(), this.symbolIdParent = Symbol();
+      const i = de(
+        () => this.update(),
+        this,
+        we(this)
+      );
+      let m, g = !0;
+      const b = ot(this);
+      this.update = () => (m || (m = !0, this.updated = (this.updated || this.mounted).then(() => {
+        try {
+          const y = i.load(this._render), p = i.cleanEffects();
+          return y && //@ts-ignore
+          y.render(this, this.symbolId, b), m = !1, g && !i.isSuspense() && (g = !1, !b && Se(this)), p();
+        } finally {
+          m = !1;
+        }
+      }).then(
+        /**
+         * @param {import("internal/hooks.js").CleanUseEffects} [cleanUseEffect]
+         */
+        (y) => {
+          y && y();
+        }
+      )), this.updated), this.update();
+    }
+    connectedCallback() {
+      this.mount(), super.connectedCallback && super.connectedCallback();
+    }
+    disconnectedCallback() {
+      super.disconnectedCallback && super.disconnectedCallback(), this.unmount();
+    }
+    /**
+     * @this {import("dom").AtomicoThisInternal}
+     * @param {string} attr
+     * @param {(string|null)} oldValue
+     * @param {(string|null)} value
+     */
+    attributeChangedCallback(c, d, i) {
+      if (n[c]) {
+        if (c === this._ignoreAttr || d === i) return;
+        const { prop: m, type: g } = n[c];
+        try {
+          this[m] = Ce(g, i);
+        } catch {
+          throw new me(
+            this,
+            `The value defined as attr '${c}' cannot be parsed by type '${g.name}'`,
+            i
+          );
+        }
+      } else
+        super.attributeChangedCallback(c, d, i);
+    }
+    static get props() {
+      return { ...super.props, ...a };
+    }
+    static get observedAttributes() {
+      const c = super.observedAttributes || [];
+      for (const d in a)
+        ge(this.prototype, d, a[d], n, s);
+      return Object.keys(n).concat(c);
+    }
+  }
+  return f;
+};
+function Se(e) {
+  const { styles: t } = e.constructor, { shadowRoot: n } = e;
+  if (n && t.length) {
+    const s = [];
+    _t(t, (o) => {
+      o && (o instanceof Element ? n.appendChild(o.cloneNode(!0)) : s.push(o));
+    }), s.length && (n.adoptedStyleSheets = s);
+  }
+}
+const Ht = (e) => (t, n) => {
+  R(
+    /**
+     * Clean the effect hook
+     * @type {import("internal/hooks.js").CollectorEffect}
+     */
+    ([s, o] = []) => ((o || !o) && (o && xt(o, n) ? s = s || !0 : (M(s) && s(), s = null)), [s, n]),
+    /**
+     * @returns {any}
+     */
+    ([s, o], r) => r ? (M(s) && s(), []) : [s || t(), o],
+    e
+  );
+}, L = Ht(Yt), Me = Ht(Ft);
+class Wt extends Array {
+  /**
+   *
+   * @param {any} initialState
+   * @param {(nextState: any, state:any[], mount: boolean )=>void} mapState
+   */
+  constructor(t, n) {
+    let s = !0;
+    const o = (r) => {
+      try {
+        n(r, this, s);
+      } finally {
+        s = !1;
+      }
+    };
+    super(void 0, o, n), o(t);
+  }
+  /**
+   * The following code allows a mutable approach to useState
+   * and useProp this with the idea of allowing an alternative
+   * approach similar to Vue or Qwik of state management
+   * @todo pending review with the community
+   */
+  // get value() {
+  //     return this[0];
+  // }
+  // set value(nextState) {
+  //     this[2](nextState, this);
+  // }
+}
+const it = (e) => {
+  const t = Lt();
+  return R(
+    (n = new Wt(e, (s, o, r) => {
+      s = M(s) ? s(o[0]) : s, s !== o[0] && (o[0] = s, r || t());
+    })) => n
+  );
+}, w = (e, t) => {
+  const [n] = R(([s, o, r = 0] = []) => ((!o || o && !xt(o, t)) && (s = e()), [s, t, r]));
+  return n;
+}, lt = (e) => {
+  const { current: t } = W();
+  if (!(e in t))
+    throw new qt(
+      t,
+      `For useProp("${e}"), the prop does not exist on the host.`,
+      e
+    );
+  return R(
+    (n = new Wt(t[e], (s, o) => {
+      s = M(s) ? s(t[e]) : s, t[e] = s;
+    })) => (n[0] = t[e], n)
+  );
+}, N = (e, t = {}) => {
+  const n = W();
+  return n[e] || (n[e] = (s = t.detail) => zt(n.current, {
+    type: e,
+    ...t,
+    detail: s
+  })), n[e];
+}, rt = x("atomico/options");
+globalThis[rt] = globalThis[rt] || {
+  sheet: !!document.adoptedStyleSheets
+};
+const K = globalThis[rt], Ne = new Promise((e) => {
+  K.ssr || (document.readyState === "loading" ? jt(document, "DOMContentLoaded", e) : e());
+}), Pe = {
+  checked: 1,
+  value: 1,
+  selected: 1
+}, ke = {
+  list: 1,
+  type: 1,
+  size: 1,
+  form: 1,
+  width: 1,
+  height: 1,
+  src: 1,
+  href: 1,
+  slot: 1
+}, Oe = {
+  shadowDom: 1,
+  staticNode: 1,
+  cloneNode: 1,
+  children: 1,
+  key: 1
+}, q = {}, at = [];
+class ct extends Text {
+}
+const Ae = x("atomico/id"), I = x("atomico/type"), Q = x("atomico/ref"), Kt = x("atomico/vnode"), Jt = () => {
+};
+function Ue(e, t, n) {
+  return Xt(this, e, t, n);
+}
+const Zt = (e, t, ...n) => {
+  const s = t || q;
+  let { children: o } = s;
+  if (o = o ?? (n.length ? n : at), e === Jt)
+    return o;
+  const r = e ? e instanceof Node ? 1 : (
+    //@ts-ignore
+    e.prototype instanceof HTMLElement && 2
+  ) : 0;
+  if (r === !1 && e instanceof Function)
+    return e(
+      o != at ? { children: o, ...s } : s
+    );
+  const a = K.render || Ue;
+  return {
+    [I]: Kt,
+    type: e,
+    props: s,
+    children: o,
+    key: s.key,
+    // key for lists by keys
+    // define if the node declares its shadowDom
+    shadow: s.shadowDom,
+    // allows renderings to run only once
+    static: s.staticNode,
+    // defines whether the type is a childNode `1` or a constructor `2`
+    raw: r,
+    // defines whether to use the second parameter for document.createElement
+    is: s.is,
+    // clone the node if it comes from a reference
+    clone: s.cloneNode,
+    render: a
+  };
+};
+function Xt(e, t, n = Ae, s, o) {
+  let r;
+  if (t && t[n] && t[n].vnode == e || e[I] != Kt)
+    return t;
+  (e || !t) && (o = o || e.type == "svg", r = e.type != "host" && (e.raw == 1 ? (t && e.clone ? t[Q] : t) != e.type : e.raw == 2 ? !(t instanceof e.type) : t ? t[Q] || t.localName != e.type : !t), r && e.type != null && (e.raw == 1 && e.clone ? (s = !0, t = e.type.cloneNode(!0), t[Q] = e.type) : t = e.raw == 1 ? e.type : e.raw == 2 ? new e.type() : o ? document.createElementNS(
+    "http://www.w3.org/2000/svg",
+    e.type
+  ) : document.createElement(
+    e.type,
+    e.is ? { is: e.is } : void 0
+  )));
+  const a = t[n] ? t[n] : q, { vnode: u = q, cycle: f = 0 } = a;
+  let { fragment: l, handlers: c } = a;
+  const { children: d = at, props: i = q } = u;
+  if (c = r ? {} : c || {}, e.static && !r) return t;
+  if (e.shadow && !t.shadowRoot && // @ts-ignore
+  t.attachShadow({ mode: "open", ...e.shadow }), e.props != i && Ye(t, i, e.props, c, o), e.children !== d) {
+    const m = e.shadow ? t.shadowRoot : t;
+    l = Re(
+      e.children,
+      /**
+       * @todo for hydration use attribute and send childNodes
+       */
+      l,
+      m,
+      n,
+      // add support to foreignObject, children will escape from svg
+      !f && s,
+      o && e.type == "foreignObject" ? !1 : o
+    );
+  }
+  return t[n] = { vnode: e, handlers: c, fragment: l, cycle: f + 1 }, t;
+}
+function $e(e, t) {
+  const n = new ct(""), s = new ct("");
+  let o;
+  if (e[t ? "prepend" : "append"](n), t) {
+    let { lastElementChild: r } = e;
+    for (; r; ) {
+      const { previousElementSibling: a } = r;
+      if (ot(r, !0) && !ot(a, !0)) {
+        o = r;
+        break;
+      }
+      r = a;
+    }
+  }
+  return o ? o.before(s) : e.append(s), {
+    markStart: n,
+    markEnd: s
+  };
+}
+function Re(e, t, n, s, o, r) {
+  e = e == null ? null : he(e) ? e : [e];
+  const a = t || $e(n, o), { markStart: u, markEnd: f, keyes: l } = a;
+  let c;
+  const d = l && /* @__PURE__ */ new Set();
+  let i = u;
+  if (e && _t(e, (m) => {
+    if (typeof m == "object" && !m[I])
+      return;
+    const g = m[I] && m.key, b = l && g != null && l.get(g);
+    i != f && i === b ? d.delete(i) : i = i == f ? f : i.nextSibling;
+    const y = l ? b : i;
+    let p = y;
+    if (m[I])
+      p = Xt(m, y, s, o, r);
+    else {
+      const v = m + "";
+      !(p instanceof Text) || p instanceof ct ? p = new Text(v) : p.data != v && (p.data = v);
+    }
+    p != i && (l && d.delete(p), !y || l ? (n.insertBefore(p, i), l && i != f && d.add(i)) : y == f ? n.insertBefore(p, f) : (n.replaceChild(p, y), i = p)), g != null && (c = c || /* @__PURE__ */ new Map(), c.set(g, p));
+  }), i = i == f ? f : i.nextSibling, t && i != f)
+    for (; i != f; ) {
+      const m = i;
+      i = i.nextSibling, m.remove();
+    }
+  return d && d.forEach((m) => m.remove()), a.keyes = c, a;
+}
+function Ye(e, t, n, s, o) {
+  for (const r in t)
+    !(r in n) && St(e, r, t[r], null, o, s);
+  for (const r in n)
+    St(e, r, t[r], n[r], o, s);
+}
+function St(e, t, n, s, o, r) {
+  if (t = t == "class" && !o ? "className" : t, n = n ?? null, s = s ?? null, t in e && Pe[t] && (n = e[t]), !(s === n || Oe[t] || t[0] == "_"))
+    if (e.localName === "slot" && t === "assignNode" && "assign" in e)
+      e.assign(s);
+    else if (t[0] == "o" && t[1] == "n" && (M(s) || M(n)))
+      Fe(e, t.slice(2), s, r);
+    else if (t == "ref")
+      s && (M(s) ? s(e) : s.current = e);
+    else if (t == "style") {
+      const { style: a } = e;
+      n = n || "", s = s || "";
+      const u = F(n), f = F(s);
+      if (u)
+        for (const l in n)
+          if (f)
+            !(l in s) && Mt(a, l, null);
+          else
+            break;
+      if (f)
+        for (const l in s) {
+          const c = s[l];
+          u && n[l] === c || Mt(a, l, c);
+        }
+      else
+        a.cssText = s;
+    } else {
+      const a = t[0] == "$" ? t.slice(1) : t;
+      a === t && (!o && !ke[t] && t in e || M(s) || M(n)) ? e[t] = s ?? "" : s == null ? e.removeAttribute(a) : e.setAttribute(
+        a,
+        F(s) ? JSON.stringify(s) : s
+      );
+    }
+}
+function Fe(e, t, n, s) {
+  if (s.handleEvent || (s.handleEvent = (o) => s[o.type].call(e, o)), n) {
+    if (!s[t]) {
+      const o = n.capture || n.once || n.passive ? Object.assign({}, n) : null;
+      e.addEventListener(t, s, o);
+    }
+    s[t] = n;
+  } else
+    s[t] && (e.removeEventListener(t, s), delete s[t]);
+}
+function Mt(e, t, n) {
+  let s = "setProperty";
+  n == null && (s = "removeProperty", n = null), ~t.indexOf("-") ? e[s](t, n) : e[t] = n;
+}
+const Ie = Zt("host", { style: "display: contents" }), Gt = "value", Le = (e, t) => {
+  const n = W(), s = It();
+  Me(
+    () => jt(
+      n.current,
+      "ConnectContext",
+      /**
+       * @param {CustomEvent<import("context").DetailConnectContext>} event
+       */
+      (o) => {
+        o.composedPath().at(0) !== o.currentTarget && e === o.detail.id && (o.stopPropagation(), o.detail.connect(s));
+      }
+    ),
+    [e]
+  ), s.current = t;
+}, ut = (e) => {
+  const t = N("ConnectContext", {
+    bubbles: !0,
+    composed: !0
+  }), [n, s] = it(() => {
+    if (K.ssr) return;
+    let r;
+    return t({
+      id: e,
+      /**
+       * @param {import("core").Ref} parentContext
+       */
+      connect(a) {
+        r = a;
+      }
+    }), r;
+  }), o = Lt();
+  return L(() => {
+    Ne.then(
+      () => t({
+        id: e,
+        connect: s
+      })
+    );
+  }, [e]), L(() => {
+    if (n)
+      return n.on(o);
+  }, [n]), n?.current || e[Gt];
+}, Qt = (e) => {
+  const t = k(
+    ({ value: n }) => (Le(t, n), Ie),
+    {
+      props: {
+        value: {
+          type: Object,
+          value: () => e
+        }
+      }
+    }
+  );
+  return t[Gt] = e, t;
+};
+Qt({
+  /**
+   *
+   * @param {string} type
+   * @param {string} id
+   */
+  dispatch(e, t) {
+  }
+});
+const Nt = {};
+function J(e, ...t) {
+  const n = (e.raw || e).reduce(
+    (s, o, r) => s + o + (t[r] || ""),
+    ""
+  );
+  return Nt[n] = Nt[n] || xe(n);
+}
+function xe(e) {
+  if (K.sheet) {
+    const t = new CSSStyleSheet();
+    return t.replaceSync(e), t;
+  } else {
+    const t = document.createElement("style");
+    return t.textContent = e, t;
+  }
+}
+const h = (e, t, n) => (t == null ? t = { key: n } : t.key = n, Zt(e, t)), S = h, ft = J`*,*:before,*:after{box-sizing:border-box}button{padding:0;touch-action:manipulation;cursor:pointer;user-select:none}`, dt = J`.vh{position:absolute;transform:scale(0)}`;
+function ht() {
+  const e = /* @__PURE__ */ new Date();
+  return new C(e.getFullYear(), e.getMonth() + 1, e.getDate());
+}
+const _e = 864e5;
+function je(e) {
+  const t = E(e);
+  t.setUTCDate(t.getUTCDate() + 3 - (t.getUTCDay() + 6) % 7);
+  const n = new Date(Date.UTC(t.getUTCFullYear(), 0, 4));
+  return 1 + Math.round(
+    ((t.getTime() - n.getTime()) / _e - 3 + (n.getUTCDay() + 6) % 7) / 7
+  );
+}
+function mt(e, t = 0) {
+  const n = E(e), s = n.getUTCDay(), o = (s < t ? 7 : 0) + s - t;
+  return n.setUTCDate(n.getUTCDate() - o), C.from(n);
+}
+function Vt(e, t = 0) {
+  return mt(e, t).add({ days: 6 });
+}
+function te(e) {
+  return C.from(new Date(Date.UTC(e.year, e.month, 0)));
+}
+function Z(e, t, n) {
+  return t && C.compare(e, t) < 0 ? t : n && C.compare(e, n) > 0 ? n : e;
+}
+const Be = { days: 1 };
+function qe(e, t = 0) {
+  let n = mt(e.toPlainDate(), t);
+  const s = Vt(te(e), t), o = [];
+  for (; C.compare(n, s) < 0; ) {
+    const r = [];
+    for (let a = 0; a < 7; a++)
+      r.push(n), n = n.add(Be);
+    o.push(r);
+  }
+  return o;
+}
+function E(e) {
+  return new Date(Date.UTC(e.year, e.month - 1, e.day ?? 1));
+}
+const ze = /^(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$/, V = (e, t) => e.toString().padStart(t, "0");
+class C {
+  constructor(t, n, s) {
+    this.year = t, this.month = n, this.day = s;
+  }
+  // this is an incomplete implementation that only handles arithmetic on a single unit at a time.
+  // i didn't want to get into more complex arithmetic since it get tricky fast
+  // this is enough to serve my needs and will still be a drop-in replacement when actual Temporal API lands
+  add(t) {
+    const n = E(this);
+    if ("days" in t)
+      return n.setUTCDate(this.day + t.days), C.from(n);
+    let { year: s, month: o } = this;
+    "months" in t ? (o = this.month + t.months, n.setUTCMonth(o - 1)) : (s = this.year + t.years, n.setUTCFullYear(s));
+    const r = C.from(E({ year: s, month: o, day: 1 }));
+    return Z(C.from(n), r, te(r));
+  }
+  toString() {
+    return `${V(this.year, 4)}-${V(this.month, 2)}-${V(this.day, 2)}`;
+  }
+  toPlainYearMonth() {
+    return new U(this.year, this.month);
+  }
+  equals(t) {
+    return C.compare(this, t) === 0;
+  }
+  static compare(t, n) {
+    return t.year < n.year ? -1 : t.year > n.year ? 1 : t.month < n.month ? -1 : t.month > n.month ? 1 : t.day < n.day ? -1 : t.day > n.day ? 1 : 0;
+  }
+  static from(t) {
+    if (typeof t == "string") {
+      const n = t.match(ze);
+      if (!n)
+        throw new TypeError(t);
+      const [, s, o, r] = n;
+      return new C(
+        parseInt(s, 10),
+        parseInt(o, 10),
+        parseInt(r, 10)
+      );
+    }
+    return new C(
+      t.getUTCFullYear(),
+      t.getUTCMonth() + 1,
+      t.getUTCDate()
+    );
+  }
+}
+class U {
+  constructor(t, n) {
+    this.year = t, this.month = n;
+  }
+  add(t) {
+    const n = E(this), s = (t.months ?? 0) + (t.years ?? 0) * 12;
+    return n.setUTCMonth(n.getUTCMonth() + s), new U(n.getUTCFullYear(), n.getUTCMonth() + 1);
+  }
+  equals(t) {
+    return this.year === t.year && this.month === t.month;
+  }
+  toPlainDate() {
+    return new C(this.year, this.month, 1);
+  }
+  static compare(t, n) {
+    return t.year < n.year ? -1 : t.year > n.year ? 1 : t.month < n.month ? -1 : t.month > n.month ? 1 : 0;
+  }
+}
+function H(e, t) {
+  if (t)
+    try {
+      return e.from(t);
+    } catch {
+    }
+}
+function P(e) {
+  const [t, n] = lt(e);
+  return [w(() => H(C, t), [t]), (r) => n(r?.toString())];
+}
+function He(e) {
+  const [t = "", n] = lt(e);
+  return [w(() => {
+    const [r, a] = t.split("/"), u = H(C, r), f = H(C, a);
+    return u && f ? [u, f] : [];
+  }, [t]), (r) => n(`${r[0]}/${r[1]}`)];
+}
+function We(e) {
+  const [t = "", n] = lt(e);
+  return [w(() => {
+    const r = [];
+    for (const a of t.trim().split(/\s+/)) {
+      const u = H(C, a);
+      u && r.push(u);
+    }
+    return r;
+  }, [t]), (r) => n(r.join(" "))];
+}
+function $(e, t) {
+  return w(
+    () => new Intl.DateTimeFormat(t, { timeZone: "UTC", ...e }),
+    [t, e]
+  );
+}
+function Pt(e, t, n) {
+  const s = $(e, n);
+  return w(() => {
+    const o = [], r = /* @__PURE__ */ new Date();
+    for (var a = 0; a < 7; a++) {
+      const u = (r.getUTCDay() - t + 7) % 7;
+      o[u] = s.format(r), r.setUTCDate(r.getUTCDate() + 1);
+    }
+    return o;
+  }, [t, s]);
+}
+const kt = (e, t, n) => Z(e, t, n) === e, Ot = (e) => e.target.matches(":dir(ltr)"), Ke = { month: "long", day: "numeric" }, Je = { month: "long" }, Ze = { weekday: "long" }, tt = { bubbles: !0 };
+function Xe({ props: e, context: t }) {
+  const { offset: n } = e, {
+    firstDayOfWeek: s,
+    isDateDisallowed: o,
+    min: r,
+    max: a,
+    today: u,
+    page: f,
+    locale: l,
+    focusedDate: c,
+    formatWeekday: d
+  } = t, i = u ?? ht(), m = Pt(Ze, s, l), g = w(
+    () => ({ weekday: d }),
+    [d]
+  ), b = Pt(g, s, l), y = $(Ke, l), p = $(Je, l), v = w(
+    () => f.start.add({ months: n }),
+    [f, n]
+  ), X = w(
+    () => qe(v, s),
+    [v, s]
+  ), se = N("focusday", tt), oe = N("selectday", tt), re = N("hoverday", tt);
+  function Dt(D) {
+    se(Z(D, r, a));
+  }
+  function ae(D) {
+    let T;
+    switch (D.key) {
+      case "ArrowRight":
+        T = c.add({ days: Ot(D) ? 1 : -1 });
+        break;
+      case "ArrowLeft":
+        T = c.add({ days: Ot(D) ? -1 : 1 });
+        break;
+      case "ArrowDown":
+        T = c.add({ days: 7 });
+        break;
+      case "ArrowUp":
+        T = c.add({ days: -7 });
+        break;
+      case "PageUp":
+        T = c.add(D.shiftKey ? { years: -1 } : { months: -1 });
+        break;
+      case "PageDown":
+        T = c.add(D.shiftKey ? { years: 1 } : { months: 1 });
+        break;
+      case "Home":
+        T = mt(c, s);
+        break;
+      case "End":
+        T = Vt(c, s);
+        break;
+      default:
+        return;
+    }
+    Dt(T), D.preventDefault();
+  }
+  function ce(D) {
+    const T = v.equals(D);
+    if (!t.showOutsideDays && !T)
+      return;
+    const ie = D.equals(c), Ct = D.equals(i), j = E(D), B = o?.(j), Tt = !kt(D, r, a);
+    let Et = "", O;
+    if (t.type === "range") {
+      const [Y, G] = t.value, vt = Y?.equals(D), wt = G?.equals(D);
+      O = Y && G && kt(D, Y, G), Et = `${vt ? "range-start" : ""} ${wt ? "range-end" : ""} ${O && !vt && !wt ? "range-inner" : ""}`;
+    } else t.type === "multi" ? O = t.value.some((Y) => Y.equals(D)) : O = t.value?.equals(D);
+    return {
+      part: `${`button day day-${j.getUTCDay()} ${// we don't want outside days to ever be shown as selected
+      T ? O ? "selected" : "" : "outside"} ${B ? "disallowed" : ""} ${Ct ? "today" : ""} ${t.getDayParts?.(j) ?? ""}`} ${Et}`,
+      tabindex: T && ie ? 0 : -1,
+      disabled: Tt,
+      "aria-disabled": B ? "true" : void 0,
+      "aria-pressed": T && O,
+      "aria-current": Ct ? "date" : void 0,
+      "aria-label": y.format(j),
+      onkeydown: ae,
+      onclick() {
+        B || oe(D), Dt(D);
+      },
+      onmouseover() {
+        !B && !Tt && re(D);
+      }
+    };
+  }
+  return {
+    weeks: X,
+    yearMonth: v,
+    daysLong: m,
+    daysVisible: b,
+    formatter: p,
+    getDayProps: ce
+  };
+}
+const et = ht(), _ = Qt({
+  type: "date",
+  firstDayOfWeek: 1,
+  focusedDate: et,
+  page: { start: et.toPlainYearMonth(), end: et.toPlainYearMonth() }
+});
+customElements.define("calendar-ctx", _);
+const Ge = (e, t) => (t + e) % 7, Qe = k(
+  (e) => {
+    const t = ut(_), n = It(), s = Xe({ props: e, context: t });
+    function o() {
+      n.current.querySelector("button[tabindex='0']")?.focus();
+    }
+    return /* @__PURE__ */ S("host", { shadowDom: !0, focus: o, children: [
+      /* @__PURE__ */ h("div", { id: "h", part: "heading", children: s.formatter.format(E(s.yearMonth)) }),
+      /* @__PURE__ */ S("table", { ref: n, "aria-labelledby": "h", part: "table", children: [
+        /* @__PURE__ */ S("colgroup", { children: [
+          t.showWeekNumbers && /* @__PURE__ */ h("col", { part: "col-weeknumber" }),
+          /* @__PURE__ */ h("col", { part: "col-1" }),
+          /* @__PURE__ */ h("col", { part: "col-2" }),
+          /* @__PURE__ */ h("col", { part: "col-3" }),
+          /* @__PURE__ */ h("col", { part: "col-4" }),
+          /* @__PURE__ */ h("col", { part: "col-5" }),
+          /* @__PURE__ */ h("col", { part: "col-6" }),
+          /* @__PURE__ */ h("col", { part: "col-7" })
+        ] }),
+        /* @__PURE__ */ h("thead", { children: /* @__PURE__ */ S("tr", { part: "tr head", children: [
+          t.showWeekNumbers && /* @__PURE__ */ h("th", { part: "th weeknumber", children: /* @__PURE__ */ S("slot", { name: "weeknumber", children: [
+            /* @__PURE__ */ h("span", { class: "vh", children: "Week" }),
+            /* @__PURE__ */ h("span", { "aria-hidden": "true", children: "#" })
+          ] }) }),
+          s.daysLong.map((r, a) => /* @__PURE__ */ S(
+            "th",
+            {
+              part: `th day day-${Ge(t.firstDayOfWeek, a)}`,
+              scope: "col",
+              children: [
+                /* @__PURE__ */ h("span", { class: "vh", children: r }),
+                /* @__PURE__ */ h("span", { "aria-hidden": "true", children: s.daysVisible[a] })
+              ]
+            }
+          ))
+        ] }) }),
+        /* @__PURE__ */ h("tbody", { children: s.weeks.map((r, a) => /* @__PURE__ */ S("tr", { part: "tr week", children: [
+          t.showWeekNumbers && /* @__PURE__ */ h("th", { class: "num", part: "th weeknumber", scope: "row", children: je(r[0]) }),
+          r.map((u, f) => {
+            const l = s.getDayProps(u);
+            return /* @__PURE__ */ h("td", { part: "td", children: l && /* @__PURE__ */ h("button", { class: "num", ...l, children: u.day }) }, f);
+          })
+        ] }, a)) })
+      ] })
+    ] });
+  },
+  {
+    props: {
+      offset: {
+        type: Number,
+        value: 0
+      }
+    },
+    styles: [
+      ft,
+      dt,
+      J`:host{--color-accent: black;--color-text-on-accent: white;display:flex;flex-direction:column;gap:.25rem;text-align:center;inline-size:fit-content}table{border-collapse:collapse;font-size:.875rem}th{inline-size:2.25rem;block-size:2.25rem}td{padding-inline:0}.num{font-variant-numeric:tabular-nums}button{color:inherit;font-size:inherit;background:transparent;border:0;block-size:2.25rem;inline-size:2.25rem}button:hover:where(:not(:disabled,[aria-disabled])){background:#0000000d}button:is([aria-pressed=true],:focus-visible){background:var(--color-accent);color:var(--color-text-on-accent)}button:focus-visible{outline:1px solid var(--color-text-on-accent);outline-offset:-2px}button:disabled,:host::part(outside),:host::part(disallowed){cursor:default;opacity:.5}`
+    ]
+  }
+);
+customElements.define("calendar-month", Qe);
+function At(e) {
+  return /* @__PURE__ */ h(
+    "button",
+    {
+      part: `button ${e.name} ${e.onclick ? "" : "disabled"}`,
+      onclick: e.onclick,
+      "aria-disabled": e.onclick ? null : "true",
+      children: /* @__PURE__ */ h("slot", { name: e.name, children: e.children })
+    }
+  );
+}
+function yt(e) {
+  const t = E(e.page.start), n = E(e.page.end);
+  return /* @__PURE__ */ h(
+    _,
+    {
+      value: e,
+      onselectday: e.onSelect,
+      onfocusday: e.onFocus,
+      onhoverday: e.onHover,
+      children: /* @__PURE__ */ S("div", { role: "group", "aria-labelledby": "h", part: "container", children: [
+        /* @__PURE__ */ h("div", { id: "h", class: "vh", "aria-live": "polite", "aria-atomic": "true", children: e.formatVerbose.formatRange(t, n) }),
+        /* @__PURE__ */ S("div", { part: "header", children: [
+          /* @__PURE__ */ h(At, { name: "previous", onclick: e.previous, children: "Previous" }),
+          /* @__PURE__ */ h("slot", { part: "heading", name: "heading", children: /* @__PURE__ */ h("div", { "aria-hidden": "true", children: e.format.formatRange(t, n) }) }),
+          /* @__PURE__ */ h(At, { name: "next", onclick: e.next, children: "Next" })
+        ] }),
+        /* @__PURE__ */ h("slot", { part: "months" })
+      ] })
+    }
+  );
+}
+const pt = {
+  value: {
+    type: String,
+    value: ""
+  },
+  min: {
+    type: String,
+    value: ""
+  },
+  max: {
+    type: String,
+    value: ""
+  },
+  today: {
+    type: String,
+    value: ""
+  },
+  isDateDisallowed: {
+    type: Function,
+    value: (e) => !1
+  },
+  formatWeekday: {
+    type: String,
+    value: () => "narrow"
+  },
+  getDayParts: {
+    type: Function,
+    value: (e) => ""
+  },
+  firstDayOfWeek: {
+    type: Number,
+    value: () => 1
+  },
+  showOutsideDays: {
+    type: Boolean,
+    value: !1
+  },
+  locale: {
+    type: String,
+    value: () => {
+    }
+  },
+  months: {
+    type: Number,
+    value: 1
+  },
+  focusedDate: {
+    type: String,
+    value: () => {
+    }
+  },
+  pageBy: {
+    type: String,
+    value: () => "months"
+  },
+  showWeekNumbers: {
+    type: Boolean,
+    value: !1
+  }
+}, gt = [
+  ft,
+  dt,
+  J`:host{display:block;inline-size:fit-content}:host::part(container){display:flex;flex-direction:column;gap:1em}:host::part(header){display:flex;align-items:center;justify-content:space-between}:host::part(heading){font-weight:700;font-size:1.25em}:host::part(button){display:flex;align-items:center;justify-content:center}:host::part(button disabled){cursor:default;opacity:.5}`
+], Ve = { year: "numeric" }, tn = { year: "numeric", month: "long" };
+function nt(e, t) {
+  return (t.year - e.year) * 12 + t.month - e.month;
+}
+const Ut = (e, t) => (e = t === 12 ? new U(e.year, 1) : e, {
+  start: e,
+  end: e.add({ months: t - 1 })
+});
+function en({
+  pageBy: e,
+  focusedDate: t,
+  months: n,
+  max: s,
+  min: o,
+  goto: r
+}) {
+  const a = e === "single" ? 1 : n, [u, f] = it(
+    () => Ut(t.toPlainYearMonth(), n)
+  ), l = (d) => f(Ut(u.start.add({ months: d }), n)), c = (d) => {
+    const i = nt(u.start, d.toPlainYearMonth());
+    return i >= 0 && i < n;
+  };
+  return L(() => {
+    if (c(t))
+      return;
+    const d = nt(t.toPlainYearMonth(), u.start);
+    r(t.add({ months: d }));
+  }, [u.start]), L(() => {
+    if (c(t))
+      return;
+    const d = nt(u.start, t.toPlainYearMonth());
+    l(d === -1 ? -a : d === n ? a : Math.floor(d / n) * n);
+  }, [t, a, n]), {
+    page: u,
+    previous: !o || !c(o) ? () => l(-a) : void 0,
+    next: !s || !c(s) ? () => l(a) : void 0
+  };
+}
+function bt({
+  months: e,
+  pageBy: t,
+  locale: n,
+  focusedDate: s,
+  setFocusedDate: o
+}) {
+  const [r] = P("min"), [a] = P("max"), [u] = P("today"), f = N("focusday"), l = N("change"), c = w(
+    () => Z(s ?? u ?? ht(), r, a),
+    [s, u, r, a]
+  );
+  function d(p) {
+    o(p), f(E(p));
+  }
+  const { next: i, previous: m, page: g } = en({
+    pageBy: t,
+    focusedDate: c,
+    months: e,
+    min: r,
+    max: a,
+    goto: d
+  }), b = W();
+  function y(p) {
+    const v = p?.target ?? "day";
+    v === "day" ? b.current.querySelectorAll("calendar-month").forEach((X) => X.focus(p)) : b.current.shadowRoot.querySelector(`[part~='${v}']`).focus(p);
+  }
+  return {
+    format: $(Ve, n),
+    formatVerbose: $(tn, n),
+    page: g,
+    focusedDate: c,
+    dispatch: l,
+    onFocus(p) {
+      p.stopPropagation(), d(p.detail), setTimeout(y);
+    },
+    min: r,
+    max: a,
+    today: u,
+    next: i,
+    previous: m,
+    focus: y
+  };
+}
+const nn = k(
+  (e) => {
+    const [t, n] = P("value"), [s = t, o] = P("focusedDate"), r = bt({
+      ...e,
+      focusedDate: s,
+      setFocusedDate: o
+    });
+    function a(u) {
+      n(u.detail), r.dispatch();
+    }
+    return /* @__PURE__ */ h("host", { shadowDom: !0, focus: r.focus, children: /* @__PURE__ */ h(
+      yt,
+      {
+        ...e,
+        ...r,
+        type: "date",
+        value: t,
+        onSelect: a
+      }
+    ) });
+  },
+  { props: pt, styles: gt }
+);
+customElements.define("calendar-date", nn);
+function ee(e) {
+  return /* @__PURE__ */ S(Jt, { children: [
+    /* @__PURE__ */ h("label", { part: "label", for: "s", children: /* @__PURE__ */ h("slot", { name: "label", children: e.label }) }),
+    /* @__PURE__ */ h("select", { id: "s", part: "select", onchange: e.onChange, children: e.options.map((t) => /* @__PURE__ */ h("option", { part: "option", ...t })) })
+  ] });
+}
+const ne = [ft, dt];
+function sn(e, t) {
+  return Array.from({ length: e }, (n, s) => t(s));
+}
+function on(e) {
+  const { min: t, max: n, focusedDate: s } = ut(_), o = N("focusday", { bubbles: !0 }), r = s.toPlainYearMonth(), a = r.year, u = Math.floor(e.maxYears / 2), f = a - u, l = a + (e.maxYears - u - 1), c = Math.max(f, t?.year ?? -1 / 0), d = Math.min(l, n?.year ?? 1 / 0), i = sn(d - c + 1, (g) => {
+    const b = c + g;
+    return {
+      label: `${b}`,
+      value: `${b}`,
+      selected: b === r.year
+    };
+  });
+  function m(g) {
+    const y = parseInt(g.currentTarget.value) - r.year;
+    o(s.add({ years: y }));
+  }
+  return { options: i, onChange: m };
+}
+const rn = k(
+  (e) => {
+    const t = on(e);
+    return /* @__PURE__ */ h("host", { shadowDom: !0, children: /* @__PURE__ */ h(ee, { label: "Year", ...t }) });
+  },
+  {
+    props: {
+      maxYears: { type: Number, value: 20 }
+    },
+    styles: ne
+  }
+);
+customElements.define("calendar-select-year", rn);
+function an(e) {
+  const { min: t, max: n, focusedDate: s, locale: o } = ut(_), r = N("focusday", { bubbles: !0 }), a = w(
+    () => ({ month: e.formatMonth }),
+    [e.formatMonth]
+  ), u = $(a, o), f = w(() => {
+    const i = [], m = /* @__PURE__ */ new Date();
+    m.setUTCDate(1);
+    for (var g = 0; g < 12; g++) {
+      const b = (m.getUTCMonth() + 12) % 12;
+      i[b] = u.format(m), m.setUTCMonth(m.getUTCMonth() + 1);
+    }
+    return i;
+  }, [u]), l = s.toPlainYearMonth(), c = f.map((i, m) => {
+    const g = m + 1, b = l.add({ months: g - l.month }), y = t != null && U.compare(b, t) < 0 || n != null && U.compare(b, n) > 0;
+    return {
+      label: i,
+      value: `${g}`,
+      disabled: y,
+      selected: g === l.month
+    };
+  });
+  function d(i) {
+    const g = parseInt(i.currentTarget.value) - l.month;
+    r(s.add({ months: g }));
+  }
+  return { options: c, onChange: d };
+}
+const cn = k(
+  (e) => {
+    const t = an(e);
+    return /* @__PURE__ */ h("host", { shadowDom: !0, children: /* @__PURE__ */ h(ee, { label: "Month", ...t }) });
+  },
+  {
+    props: {
+      formatMonth: {
+        type: String,
+        value: () => "long"
+      }
+    },
+    styles: ne
+  }
+);
+customElements.define("calendar-select-month", cn);
+const $t = (e, t) => C.compare(e, t) < 0 ? [e, t] : [t, e], ln = k(
+  (e) => {
+    const [t, n] = He("value"), [s = t[0], o] = P("focusedDate"), r = bt({
+      ...e,
+      focusedDate: s,
+      setFocusedDate: o
+    }), a = N("rangestart"), u = N("rangeend"), [f, l] = P(
+      "tentative"
+    ), [c, d] = it();
+    L(() => d(void 0), [f]);
+    function i(y) {
+      r.onFocus(y), m(y);
+    }
+    function m(y) {
+      y.stopPropagation(), f && d(y.detail);
+    }
+    function g(y) {
+      const p = y.detail;
+      y.stopPropagation(), f ? (n($t(f, p)), l(void 0), u(E(p)), r.dispatch()) : (l(p), a(E(p)));
+    }
+    const b = f ? $t(f, c ?? f) : t;
+    return /* @__PURE__ */ h("host", { shadowDom: !0, focus: r.focus, children: /* @__PURE__ */ h(
+      yt,
+      {
+        ...e,
+        ...r,
+        type: "range",
+        value: b,
+        onFocus: i,
+        onHover: m,
+        onSelect: g
+      }
+    ) });
+  },
+  {
+    props: {
+      ...pt,
+      tentative: {
+        type: String,
+        value: ""
+      }
+    },
+    styles: gt
+  }
+);
+customElements.define("calendar-range", ln);
+const un = k(
+  (e) => {
+    const [t, n] = We("value"), [s = t[0], o] = P("focusedDate"), r = bt({
+      ...e,
+      focusedDate: s,
+      setFocusedDate: o
+    });
+    function a(u) {
+      const f = [...t], l = t.findIndex((c) => c.equals(u.detail));
+      l < 0 ? f.push(u.detail) : f.splice(l, 1), n(f), r.dispatch();
+    }
+    return /* @__PURE__ */ h("host", { shadowDom: !0, focus: r.focus, children: /* @__PURE__ */ h(
+      yt,
+      {
+        ...e,
+        ...r,
+        type: "multi",
+        value: t,
+        onSelect: a
+      }
+    ) });
+  },
+  { props: pt, styles: gt }
+);
+customElements.define("calendar-multi", un);
+export {
+  nn as CalendarDate,
+  Qe as CalendarMonth,
+  un as CalendarMulti,
+  ln as CalendarRange,
+  cn as CalendarSelectMonth,
+  rn as CalendarSelectYear
+};

--- a/app/views/kiso/components/_calendar.html.erb
+++ b/app/views/kiso/components/_calendar.html.erb
@@ -1,0 +1,26 @@
+<%# locals: (mode: :single, value: nil, min: nil, max: nil, color: :primary, variant: :solid, size: :md, locale: nil, show_outside_days: true, months: 1, first_day_of_week: nil, css_classes: "", **component_options) %>
+<%
+  calendar_tag = (mode == :range) ? "calendar-range" : "calendar-date"
+  cally_attrs = {
+    value: value,
+    min: min,
+    max: max,
+    locale: locale,
+    months: (months > 1 ? months : nil),
+    "show-outside-days": (show_outside_days ? "" : nil),
+    "first-day-of-week": first_day_of_week
+  }.compact
+%>
+<%= content_tag :div,
+    class: Kiso::Themes::Calendar.render(color: color, variant: variant, size: size, class: css_classes),
+    data: kiso_prepare_options(component_options, slot: "calendar", variant: variant, controller: "kiso--calendar"),
+    **component_options do %>
+  <%= content_tag calendar_tag, **cally_attrs do %>
+    <%= kiso_component_icon(:chevron_left, slot: "previous", class: "size-4") %>
+    <% months.times do |i| %>
+      <%= tag.send(:"calendar-month", offset: (i > 0 ? i : nil)) %>
+    <% end %>
+    <%= kiso_component_icon(:chevron_right, slot: "next", class: "size-4") %>
+    <%= yield if block_given? %>
+  <% end %>
+<% end %>

--- a/app/views/kiso/components/_date_picker.html.erb
+++ b/app/views/kiso/components/_date_picker.html.erb
@@ -1,0 +1,43 @@
+<%# locals: (value: nil, placeholder: "Pick a date", color: :primary, variant: :solid, size: :md, min: nil, max: nil, locale: nil, name: nil, required: false, months: 1, mode: :single, button_variant: :outline, button_size: :md, show_outside_days: true, css_classes: "", **component_options) %>
+<%
+  popover_id = "dp-#{SecureRandom.hex(4)}"
+  display_text = if value.present?
+    date = Date.parse(value.to_s)
+    date.strftime("%B %-d, %Y")
+  else
+    placeholder
+  end
+  display_classes = value.blank? ? "text-muted-foreground" : ""
+%>
+<%= content_tag :div,
+    class: css_classes.presence,
+    data: kiso_prepare_options(component_options, slot: "date-picker", controller: "kiso--date-picker",
+      kiso__date_picker_format_value: "long",
+      **(locale ? {kiso__date_picker_locale_value: locale} : {})),
+    **component_options do %>
+  <% if name %>
+    <%= tag.input type: "hidden", name: name, value: value,
+        required: (required || nil),
+        data: { kiso__date_picker_target: "input" } %>
+  <% else %>
+    <%= tag.input type: "hidden", value: value,
+        data: { kiso__date_picker_target: "input" } %>
+  <% end %>
+
+  <%= kui(:button, variant: button_variant, size: button_size,
+      css_classes: "w-[280px] justify-start text-left font-normal",
+      data: { kiso__date_picker_target: "trigger" },
+      popovertarget: popover_id) do %>
+    <%= kiso_component_icon(:calendar) %>
+    <%= tag.span display_text, class: display_classes,
+        data: { kiso__date_picker_target: "display" } %>
+  <% end %>
+
+  <%= content_tag :div, id: popover_id, popover: "",
+      class: Kiso::Themes::DatePickerPopover.render,
+      data: { kiso__date_picker_target: "popover" } do %>
+    <%= kui(:calendar, mode: mode, value: value, min: min, max: max,
+        color: color, variant: variant, size: size, locale: locale,
+        show_outside_days: show_outside_days, months: months) %>
+  <% end %>
+<% end %>

--- a/app/views/kiso/components/_input_date.html.erb
+++ b/app/views/kiso/components/_input_date.html.erb
@@ -1,0 +1,60 @@
+<%# locals: (value: nil, name: nil, variant: :outline, size: :md, required: false, disabled: false, css_classes: "", **component_options) %>
+<%
+  segments = if value.present?
+    date = Date.parse(value.to_s)
+    { month: date.month, day: date.day, year: date.year }
+  else
+    { month: nil, day: nil, year: nil }
+  end
+%>
+<%= content_tag :div,
+    class: Kiso::Themes::InputDate.render(variant: variant, size: size, class: css_classes),
+    data: kiso_prepare_options(component_options, slot: "input-date", controller: "kiso--input-date",
+      **(value ? { kiso__input_date_value_value: value } : {})),
+    **component_options do %>
+
+  <% if name %>
+    <%= tag.input type: "hidden", name: name, value: value,
+        required: (required || nil),
+        data: { kiso__input_date_target: "input" } %>
+  <% else %>
+    <%= tag.input type: "hidden", value: value,
+        data: { kiso__input_date_target: "input" } %>
+  <% end %>
+
+  <%= tag.span(
+    segments[:month] ? segments[:month].to_s.rjust(2, "0") : "MM",
+    class: Kiso::Themes::InputDateSegment.render(size: size),
+    tabindex: (disabled ? nil : "0"),
+    role: "spinbutton",
+    aria: { label: "Month", valuemin: 1, valuemax: 12, valuenow: segments[:month] },
+    data: { segment: "month", kiso__input_date_target: "segment",
+            action: "keydown->kiso--input-date#keydown",
+            **(segments[:month] ? {} : { placeholder: "" }) }) %>
+
+  <%= tag.span "/", class: Kiso::Themes::InputDateSeparator.render,
+      data: { slot: "input-date-separator" } %>
+
+  <%= tag.span(
+    segments[:day] ? segments[:day].to_s.rjust(2, "0") : "DD",
+    class: Kiso::Themes::InputDateSegment.render(size: size),
+    tabindex: (disabled ? nil : "0"),
+    role: "spinbutton",
+    aria: { label: "Day", valuemin: 1, valuemax: 31, valuenow: segments[:day] },
+    data: { segment: "day", kiso__input_date_target: "segment",
+            action: "keydown->kiso--input-date#keydown",
+            **(segments[:day] ? {} : { placeholder: "" }) }) %>
+
+  <%= tag.span "/", class: Kiso::Themes::InputDateSeparator.render,
+      data: { slot: "input-date-separator" } %>
+
+  <%= tag.span(
+    segments[:year] ? segments[:year].to_s.rjust(4, "0") : "YYYY",
+    class: Kiso::Themes::InputDateSegment.render(size: size),
+    tabindex: (disabled ? nil : "0"),
+    role: "spinbutton",
+    aria: { label: "Year", valuemin: 1900, valuemax: 2099, valuenow: segments[:year] },
+    data: { segment: "year", kiso__input_date_target: "segment",
+            action: "keydown->kiso--input-date#keydown",
+            **(segments[:year] ? {} : { placeholder: "" }) }) %>
+<% end %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -8,3 +8,6 @@ pin_all_from Kiso::Engine.root.join("app/javascript/kiso/utils"),
 # Floating UI — vendored browser ESM builds for smart positioning
 pin "@floating-ui/core", to: "kiso/vendor/floating-ui-core.js"
 pin "@floating-ui/dom", to: "kiso/vendor/floating-ui-dom.js"
+
+# Cally — vendored web component calendar (single bundle includes Atomico)
+pin "cally", to: "kiso/vendor/cally.js"

--- a/docs/src/_data/navigation.yml
+++ b/docs/src/_data/navigation.yml
@@ -70,14 +70,20 @@ docs:
 
   - heading: Forms
     items:
+      - title: Calendar
+        href: /components/calendar
       - title: Checkbox
         href: /components/checkbox
       - title: Combobox
         href: /components/combobox
+      - title: DatePicker
+        href: /components/date-picker
       - title: Field
         href: /components/field
       - title: Input
         href: /components/input
+      - title: InputDate
+        href: /components/input-date
       - title: RadioGroup
         href: /components/radio_group
       - title: Select

--- a/docs/src/components/calendar.md
+++ b/docs/src/components/calendar.md
@@ -1,0 +1,74 @@
+---
+title: Calendar
+layout: docs
+description: Displays a date grid for date selection, powered by Cally web components.
+category: Form
+source: lib/kiso/themes/calendar.rb
+---
+
+## Quick Start
+
+```erb
+<%%= kui(:calendar, value: Date.today.iso8601) %>
+```
+
+## Locals
+
+| Local | Type | Default |
+|-------|------|---------|
+| `mode:` | `:single` \| `:range` | `:single` |
+| `value:` | `String` (ISO 8601) | `nil` |
+| `min:` | `String` (ISO 8601) | `nil` |
+| `max:` | `String` (ISO 8601) | `nil` |
+| `color:` | `:primary` \| `:secondary` \| `:success` \| `:info` \| `:warning` \| `:error` \| `:neutral` | `:primary` |
+| `variant:` | `:solid` \| `:outline` \| `:soft` \| `:subtle` | `:solid` |
+| `size:` | `:sm` \| `:md` \| `:lg` | `:md` |
+| `locale:` | `String` | `nil` (browser default) |
+| `show_outside_days:` | `Boolean` | `true` |
+| `months:` | `Integer` | `1` |
+| `first_day_of_week:` | `Integer` (0=Sun, 1=Mon) | `nil` (Cally default) |
+| `css_classes:` | `String` | `""` |
+| `**component_options` | `Hash` | `{}` |
+
+## Usage
+
+### Color
+
+```erb
+<%%= kui(:calendar, color: :success, value: "2026-03-15") %>
+<%%= kui(:calendar, color: :error, value: "2026-03-15") %>
+```
+
+### Variant
+
+```erb
+<%%= kui(:calendar, variant: :solid, value: "2026-03-15") %>
+<%%= kui(:calendar, variant: :outline, value: "2026-03-15") %>
+<%%= kui(:calendar, variant: :soft, value: "2026-03-15") %>
+<%%= kui(:calendar, variant: :subtle, value: "2026-03-15") %>
+```
+
+### Range Selection
+
+```erb
+<%%= kui(:calendar, mode: :range, months: 2) %>
+```
+
+### Multiple Months
+
+```erb
+<%%= kui(:calendar, months: 3, value: "2026-03-15") %>
+```
+
+### Min / Max Constraints
+
+```erb
+<%%= kui(:calendar, min: "2026-03-01", max: "2026-03-31") %>
+```
+
+## Dependencies
+
+Calendar wraps [Cally](https://wicky.nillia.ms/cally/) web components.
+The Cally library is vendored in the engine — no additional installation
+needed for importmap apps. Bundler apps should install `cally` as a peer
+dependency.

--- a/docs/src/components/date-picker.md
+++ b/docs/src/components/date-picker.md
@@ -1,0 +1,79 @@
+---
+title: Date Picker
+layout: docs
+description: A button that opens a calendar popover for date selection.
+category: Form
+source: lib/kiso/themes/date_picker.rb
+---
+
+## Quick Start
+
+```erb
+<%%= kui(:date_picker, name: "event_date") %>
+```
+
+## Locals
+
+| Local | Type | Default |
+|-------|------|---------|
+| `value:` | `String` (ISO 8601) | `nil` |
+| `placeholder:` | `String` | `"Pick a date"` |
+| `name:` | `String` | `nil` |
+| `required:` | `Boolean` | `false` |
+| `color:` | `:primary` \| `:secondary` \| `:success` \| `:info` \| `:warning` \| `:error` \| `:neutral` | `:primary` |
+| `variant:` | `:solid` \| `:outline` \| `:soft` \| `:subtle` | `:solid` |
+| `size:` | `:sm` \| `:md` \| `:lg` | `:md` |
+| `min:` | `String` (ISO 8601) | `nil` |
+| `max:` | `String` (ISO 8601) | `nil` |
+| `locale:` | `String` | `nil` |
+| `months:` | `Integer` | `1` |
+| `mode:` | `:single` \| `:range` | `:single` |
+| `button_variant:` | Symbol | `:outline` |
+| `button_size:` | Symbol | `:md` |
+| `show_outside_days:` | `Boolean` | `true` |
+| `css_classes:` | `String` | `""` |
+| `**component_options` | `Hash` | `{}` |
+
+## Usage
+
+### Basic
+
+```erb
+<%%= kui(:date_picker, name: "date") %>
+```
+
+### With Pre-selected Value
+
+```erb
+<%%= kui(:date_picker, value: Date.today.iso8601, name: "start_date") %>
+```
+
+### In a Form
+
+```erb
+<%%= kui(:field) do %>
+  <%%= kui(:field, :label) { "Event Date" } %>
+  <%%= kui(:date_picker, name: "event[date]", required: true) %>
+  <%%= kui(:field, :description) { "Choose when the event takes place." } %>
+<%% end %>
+```
+
+### With Constraints
+
+```erb
+<%%= kui(:date_picker, name: "booking_date",
+    min: Date.today.iso8601,
+    max: (Date.today + 90).iso8601) %>
+```
+
+## How It Works
+
+Date Picker composes three existing primitives:
+
+1. **Button** — trigger with calendar icon and date display
+2. **Popover** — native `[popover]` API with Floating UI positioning
+3. **Calendar** — Cally web component for date grid
+
+When a date is selected, the popover closes automatically and the button
+updates to show the formatted date. The ISO 8601 value is synced to a
+hidden `<input>` for form submission.

--- a/docs/src/components/input-date.md
+++ b/docs/src/components/input-date.md
@@ -1,0 +1,77 @@
+---
+title: Input Date
+layout: docs
+description: A segmented date input with individual month, day, and year fields.
+category: Form
+source: lib/kiso/themes/input_date.rb
+---
+
+## Quick Start
+
+```erb
+<%%= kui(:input_date, name: "birth_date") %>
+```
+
+## Locals
+
+| Local | Type | Default |
+|-------|------|---------|
+| `value:` | `String` (ISO 8601) | `nil` |
+| `name:` | `String` | `nil` |
+| `variant:` | `:outline` \| `:soft` \| `:ghost` | `:outline` |
+| `size:` | `:sm` \| `:md` \| `:lg` | `:md` |
+| `required:` | `Boolean` | `false` |
+| `disabled:` | `Boolean` | `false` |
+| `css_classes:` | `String` | `""` |
+| `**component_options` | `Hash` | `{}` |
+
+## Usage
+
+### Basic
+
+```erb
+<%%= kui(:input_date, name: "date") %>
+```
+
+### With Value
+
+```erb
+<%%= kui(:input_date, value: "2026-03-15", name: "date") %>
+```
+
+### In a Form
+
+```erb
+<%%= kui(:field) do %>
+  <%%= kui(:field, :label) { "Birth Date" } %>
+  <%%= kui(:input_date, name: "person[birth_date]", required: true) %>
+  <%%= kui(:field, :description) { "Enter your date of birth." } %>
+<%% end %>
+```
+
+### Sizes
+
+```erb
+<%%= kui(:input_date, size: :sm) %>
+<%%= kui(:input_date, size: :md) %>
+<%%= kui(:input_date, size: :lg) %>
+```
+
+## Keyboard Navigation
+
+| Key | Action |
+|-----|--------|
+| Arrow Up | Increment segment value |
+| Arrow Down | Decrement segment value |
+| Arrow Right | Move to next segment |
+| Arrow Left | Move to previous segment |
+| Number keys | Type value (auto-advances when complete) |
+| Backspace | Clear segment |
+| Tab | Move to next segment (browser native) |
+
+## How It Works
+
+Each segment (MM, DD, YYYY) is an independent `<span>` with
+`role="spinbutton"` and full ARIA attributes. A Stimulus controller
+handles keyboard input, validates ranges, and syncs the combined ISO 8601
+value to a hidden `<input>` for form submission.

--- a/lib/kiso.rb
+++ b/lib/kiso.rb
@@ -38,6 +38,9 @@ require "kiso/themes/kbd"
 require "kiso/themes/color_mode_button"
 require "kiso/themes/color_mode_select"
 require "kiso/themes/dashboard"
+require "kiso/themes/calendar"
+require "kiso/themes/date_picker"
+require "kiso/themes/input_date"
 require "kiso/icons"
 
 # Kiso — a Rails engine providing UI components inspired by shadcn/ui and Nuxt UI.

--- a/lib/kiso/configuration.rb
+++ b/lib/kiso/configuration.rb
@@ -44,7 +44,8 @@ module Kiso
         sun: "sun",
         moon: "moon",
         monitor: "monitor",
-        menu: "menu"
+        menu: "menu",
+        calendar: "calendar-days"
       }
     end
   end

--- a/lib/kiso/themes/calendar.rb
+++ b/lib/kiso/themes/calendar.rb
@@ -1,0 +1,77 @@
+module Kiso
+  module Themes
+    # Calendar date grid wrapping Cally web components.
+    #
+    # Since Cally renders inside Shadow DOM, most visual styling lives in
+    # +calendar.css+ via +::part()+ selectors. This theme module provides:
+    # - Wrapper classes (layout, padding, text color)
+    # - CSS custom property mappings for color × variant (consumed by +::part()+ rules)
+    #
+    # The +color+ / +variant+ axes control the selected-date cell styling
+    # through CSS custom properties (+--cally-color+, +--cally-color-fg+),
+    # following the same compound variant formulas as Badge/Alert/Button.
+    #
+    # @example
+    #   Calendar.render(color: :primary, variant: :solid, size: :md)
+    #
+    # Variants:
+    # - +color+ — :primary (default), :secondary, :success, :info, :warning, :error, :neutral
+    # - +variant+ — :solid (default), :outline, :soft, :subtle
+    # - +size+ — :sm, :md (default), :lg
+    Calendar = ClassVariants.build(
+      base: "text-foreground inline-block",
+      variants: {
+        variant: {
+          solid: "",
+          outline: "",
+          soft: "",
+          subtle: ""
+        },
+        size: {
+          sm: "[--cally-cell:1.75rem] text-xs",
+          md: "[--cally-cell:2rem] text-sm",
+          lg: "[--cally-cell:2.25rem] text-base"
+        },
+        color: COLORS.index_with { "" }
+      },
+      compound_variants: [
+        # -- solid: selected cell gets bg-{color} text-{color}-foreground --
+        {color: :primary, variant: :solid, class: "[--cally-color:var(--color-primary)] [--cally-color-fg:var(--color-primary-foreground)]"},
+        {color: :secondary, variant: :solid, class: "[--cally-color:var(--color-secondary)] [--cally-color-fg:var(--color-secondary-foreground)]"},
+        {color: :success, variant: :solid, class: "[--cally-color:var(--color-success)] [--cally-color-fg:var(--color-success-foreground)]"},
+        {color: :info, variant: :solid, class: "[--cally-color:var(--color-info)] [--cally-color-fg:var(--color-info-foreground)]"},
+        {color: :warning, variant: :solid, class: "[--cally-color:var(--color-warning)] [--cally-color-fg:var(--color-warning-foreground)]"},
+        {color: :error, variant: :solid, class: "[--cally-color:var(--color-error)] [--cally-color-fg:var(--color-error-foreground)]"},
+        {color: :neutral, variant: :solid, class: "[--cally-color:var(--color-inverted)] [--cally-color-fg:var(--color-inverted-foreground)]"},
+
+        # -- outline: selected cell gets ring + text-{color} --
+        {color: :primary, variant: :outline, class: "[--cally-color:var(--color-primary)] [--cally-color-fg:var(--color-primary)]"},
+        {color: :secondary, variant: :outline, class: "[--cally-color:var(--color-secondary)] [--cally-color-fg:var(--color-secondary)]"},
+        {color: :success, variant: :outline, class: "[--cally-color:var(--color-success)] [--cally-color-fg:var(--color-success)]"},
+        {color: :info, variant: :outline, class: "[--cally-color:var(--color-info)] [--cally-color-fg:var(--color-info)]"},
+        {color: :warning, variant: :outline, class: "[--cally-color:var(--color-warning)] [--cally-color-fg:var(--color-warning)]"},
+        {color: :error, variant: :outline, class: "[--cally-color:var(--color-error)] [--cally-color-fg:var(--color-error)]"},
+        {color: :neutral, variant: :outline, class: "[--cally-color:var(--color-accented)] [--cally-color-fg:var(--color-foreground)]"},
+
+        # -- soft: selected cell gets bg-{color}/10 text-{color} --
+        {color: :primary, variant: :soft, class: "[--cally-color:var(--color-primary)] [--cally-color-fg:var(--color-primary)]"},
+        {color: :secondary, variant: :soft, class: "[--cally-color:var(--color-secondary)] [--cally-color-fg:var(--color-secondary)]"},
+        {color: :success, variant: :soft, class: "[--cally-color:var(--color-success)] [--cally-color-fg:var(--color-success)]"},
+        {color: :info, variant: :soft, class: "[--cally-color:var(--color-info)] [--cally-color-fg:var(--color-info)]"},
+        {color: :warning, variant: :soft, class: "[--cally-color:var(--color-warning)] [--cally-color-fg:var(--color-warning)]"},
+        {color: :error, variant: :soft, class: "[--cally-color:var(--color-error)] [--cally-color-fg:var(--color-error)]"},
+        {color: :neutral, variant: :soft, class: "[--cally-color:var(--color-elevated)] [--cally-color-fg:var(--color-foreground)]"},
+
+        # -- subtle: selected cell gets bg-{color}/10 text-{color} ring-{color}/25 --
+        {color: :primary, variant: :subtle, class: "[--cally-color:var(--color-primary)] [--cally-color-fg:var(--color-primary)]"},
+        {color: :secondary, variant: :subtle, class: "[--cally-color:var(--color-secondary)] [--cally-color-fg:var(--color-secondary)]"},
+        {color: :success, variant: :subtle, class: "[--cally-color:var(--color-success)] [--cally-color-fg:var(--color-success)]"},
+        {color: :info, variant: :subtle, class: "[--cally-color:var(--color-info)] [--cally-color-fg:var(--color-info)]"},
+        {color: :warning, variant: :subtle, class: "[--cally-color:var(--color-warning)] [--cally-color-fg:var(--color-warning)]"},
+        {color: :error, variant: :subtle, class: "[--cally-color:var(--color-error)] [--cally-color-fg:var(--color-error)]"},
+        {color: :neutral, variant: :subtle, class: "[--cally-color:var(--color-elevated)] [--cally-color-fg:var(--color-foreground)]"}
+      ],
+      defaults: {color: :primary, variant: :solid, size: :md}
+    )
+  end
+end

--- a/lib/kiso/themes/date_picker.rb
+++ b/lib/kiso/themes/date_picker.rb
@@ -1,0 +1,13 @@
+module Kiso
+  module Themes
+    # Date picker popover container.
+    #
+    # @example
+    #   DatePickerPopover.render
+    DatePickerPopover = ClassVariants.build(
+      base: "m-0 rounded-lg border bg-background text-foreground shadow-md p-0",
+      variants: {},
+      defaults: {}
+    )
+  end
+end

--- a/lib/kiso/themes/input_date.rb
+++ b/lib/kiso/themes/input_date.rb
@@ -1,0 +1,59 @@
+module Kiso
+  module Themes
+    # Segmented date input — wrapper styled like a standard input.
+    #
+    # @example
+    #   InputDate.render(variant: :outline, size: :md)
+    #
+    # Variants:
+    # - +variant+ — :outline (default), :soft, :ghost
+    # - +size+ — :sm, :md (default), :lg
+    InputDate = ClassVariants.build(
+      base: "text-foreground inline-flex items-center rounded-md select-none " \
+            "transition-[color,box-shadow] " \
+            "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 " \
+            "focus-within:ring-2 focus-within:ring-inset focus-within:ring-primary",
+      variants: {
+        variant: {
+          outline: "bg-background ring ring-inset ring-accented shadow-xs",
+          soft: "bg-elevated/50",
+          ghost: "bg-transparent"
+        },
+        size: {
+          sm: "h-8 px-2.5 gap-0.5 text-sm",
+          md: "h-9 px-3 gap-0.5 text-base md:text-sm",
+          lg: "h-10 px-3 gap-0.5 text-base"
+        }
+      },
+      defaults: {variant: :outline, size: :md}
+    )
+
+    # Individual segment within the date input (day, month, year).
+    #
+    # @example
+    #   InputDateSegment.render(size: :md)
+    InputDateSegment = ClassVariants.build(
+      base: "rounded text-center outline-hidden tabular-nums " \
+            "data-[placeholder]:text-muted-foreground " \
+            "focus:bg-primary focus:text-primary-foreground",
+      variants: {
+        size: {
+          sm: "py-0.5 text-sm",
+          md: "py-0.5 text-base md:text-sm",
+          lg: "py-1 text-base"
+        }
+      },
+      defaults: {size: :md}
+    )
+
+    # Separator between date segments (e.g., "/").
+    #
+    # @example
+    #   InputDateSeparator.render
+    InputDateSeparator = ClassVariants.build(
+      base: "text-muted-foreground select-none",
+      variants: {},
+      defaults: {}
+    )
+  end
+end

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,17 +8,19 @@
       "name": "kiso-ui",
       "version": "0.1.1",
       "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
       "devDependencies": {
         "@axe-core/playwright": "^4.11.1",
-        "@floating-ui/dom": "^1.7.5",
         "@playwright/test": "^1.58.2",
+        "cally": "^0.9.2",
         "jsdom": "^28.1.0",
         "oxfmt": "^0.35.0",
         "oxlint": "^1.50.0",
         "vitest": "^4.0.18"
       },
       "peerDependencies": {
-        "@floating-ui/dom": ">=1.0.0",
         "@hotwired/stimulus": ">=3.0.0"
       }
     },
@@ -689,7 +691,6 @@
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
       "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/utils": "^0.2.10"
@@ -699,7 +700,6 @@
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
       "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/core": "^1.7.4",
@@ -710,7 +710,6 @@
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@hotwired/stimulus": {
@@ -1902,6 +1901,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/atomico": {
+      "version": "1.79.2",
+      "resolved": "https://registry.npmjs.org/atomico/-/atomico-1.79.2.tgz",
+      "integrity": "sha512-mshhLRMeIltNYbnQnqgnrvJ/uDa8XDfTQcjw3ymOygQqwHIQ4Sp0LcNYMCbACkV3DtV+eDXb9szwU4qMUuGwYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/axe-core": {
       "version": "4.11.1",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
@@ -1920,6 +1926,16 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/cally": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/cally/-/cally-0.9.2.tgz",
+      "integrity": "sha512-zY/Ueh+p6O+LKPYqNB13dATgNuazAHS0n3JbtKyUmMoQfRq5mC2/zFI3UV2X3g+2lZn2BBwr1Z+HxyG9Dt/6lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atomico": "^1.79.2"
       }
     },
     "node_modules/chai": {

--- a/package.json
+++ b/package.json
@@ -41,11 +41,13 @@
     "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
-    "@floating-ui/dom": "^1.0.0"
+    "@floating-ui/dom": "^1.0.0",
+    "cally": "^0.9.0"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.1",
     "@playwright/test": "^1.58.2",
+    "cally": "^0.9.2",
     "jsdom": "^28.1.0",
     "oxfmt": "^0.35.0",
     "oxlint": "^1.50.0",

--- a/project/components/calendar.md
+++ b/project/components/calendar.md
@@ -1,0 +1,45 @@
+# Calendar — Component Vision
+
+## Current API
+
+Standalone calendar grid wrapping Cally web components. Supports single
+date selection, range selection, and multi-month views.
+
+```erb
+<%# Single date %>
+<%= kui(:calendar, value: Date.today.iso8601) %>
+
+<%# Range selection with two months %>
+<%= kui(:calendar, mode: :range, months: 2) %>
+
+<%# Colored variant %>
+<%= kui(:calendar, color: :success, variant: :soft, value: "2026-03-15") %>
+```
+
+**Locals:** `mode:`, `value:`, `min:`, `max:`, `color:`, `variant:`, `size:`,
+`locale:`, `show_outside_days:`, `months:`, `first_day_of_week:`,
+`css_classes:`, `**component_options`
+
+## Architecture
+
+- Wraps [Cally](https://wicky.nillia.ms/cally/) web components (`<calendar-date>`, `<calendar-range>`)
+- Vendored ESM build in `app/javascript/kiso/vendor/cally.js`
+- Styling via `::part()` CSS selectors in `calendar.css`
+- Color × variant compound variants set CSS custom properties (`--cally-color`, `--cally-color-fg`)
+- Dark mode works automatically via CSS variable swapping
+
+## Key Design Decisions
+
+- **Cally dispatches `change` with `bubbles: false`** — must listen directly
+  on the `<calendar-date>` element, not via event delegation or `data-action`
+- **`::part()` for Shadow DOM styling** — confirmed in prototype that all
+  needed parts are reachable (selected, today, outside, range, disabled)
+- **CSS custom properties bridge theme module → CSS** — the Ruby theme sets
+  `--cally-color` via Tailwind arbitrary properties, `::part()` rules reference them
+
+## Files
+
+- `lib/kiso/themes/calendar.rb`
+- `app/views/kiso/components/_calendar.html.erb`
+- `app/assets/tailwind/kiso/calendar.css`
+- `app/javascript/kiso/vendor/cally.js`

--- a/project/components/date-picker.md
+++ b/project/components/date-picker.md
@@ -1,0 +1,54 @@
+# Date Picker — Component Vision
+
+## Current API
+
+Composes a trigger button, native popover, and calendar for date selection.
+Syncs the selected date to a hidden input for form submission.
+
+```erb
+<%# Basic %>
+<%= kui(:date_picker, name: "event_date") %>
+
+<%# With pre-selected value %>
+<%= kui(:date_picker, value: Date.today.iso8601, name: "start_date") %>
+
+<%# In a form with Field wrapper %>
+<%= kui(:field) do %>
+  <%= kui(:field, :label) { "Event Date" } %>
+  <%= kui(:date_picker, name: "event[date]", required: true) %>
+<% end %>
+```
+
+**Locals:** `value:`, `placeholder:`, `color:`, `variant:`, `size:`, `min:`,
+`max:`, `locale:`, `name:`, `required:`, `months:`, `mode:`,
+`button_variant:`, `button_size:`, `show_outside_days:`,
+`css_classes:`, `**component_options`
+
+## Architecture
+
+- Trigger button uses `kui(:button)` with `popovertarget` attribute
+- Popover uses native `[popover]` API + Floating UI for positioning
+- Calendar inside popover uses `kui(:calendar)` (Cally web components)
+- Stimulus controller (`kiso--date-picker`) wires the flow:
+  - Listens for popover `toggle` event to start/stop Floating UI
+  - Listens for Cally `change` event via `customElements.whenDefined()`
+  - Updates display text via `Intl.DateTimeFormat`
+  - Syncs ISO 8601 value to hidden input
+  - Closes popover on selection
+
+## Key Design Decisions
+
+- **Native `[popover]` instead of `kui(:popover)`** — lighter, fewer
+  dependencies between components. Popover open/close is handled by the
+  browser, controller just manages positioning.
+- **`customElements.whenDefined()` for Cally event listener** — Stimulus
+  controller connects before Cally's custom element upgrades. Must wait
+  for the element to be defined before attaching the `change` listener.
+- **`SecureRandom.hex(4)` for popover IDs** — supports multiple pickers
+  on the same page without ID collisions.
+
+## Files
+
+- `lib/kiso/themes/date_picker.rb`
+- `app/views/kiso/components/_date_picker.html.erb`
+- `app/javascript/controllers/kiso/date_picker_controller.js`

--- a/project/components/input-date.md
+++ b/project/components/input-date.md
@@ -1,0 +1,52 @@
+# Input Date — Component Vision
+
+## Current API
+
+Segmented date input with individual month, day, and year fields.
+Keyboard-driven: arrow keys increment/decrement, number typing with
+auto-advance, tab between segments.
+
+```erb
+<%# Empty %>
+<%= kui(:input_date, name: "birth_date") %>
+
+<%# With value %>
+<%= kui(:input_date, value: Date.today.iso8601, name: "birth_date") %>
+
+<%# In a form with Field wrapper %>
+<%= kui(:field) do %>
+  <%= kui(:field, :label) { "Birth Date" } %>
+  <%= kui(:input_date, name: "person[birth_date]", required: true) %>
+<% end %>
+```
+
+**Locals:** `value:`, `name:`, `variant:`, `size:`, `required:`, `disabled:`,
+`css_classes:`, `**component_options`
+
+## Architecture
+
+- Wrapper styled like `kui(:input)` (same border, ring, focus patterns)
+- Three `<span>` segments with `role="spinbutton"` and ARIA attributes
+- Stimulus controller (`kiso--input-date`) handles all keyboard interaction:
+  - ArrowUp/Down: increment/decrement within valid range (wraps)
+  - ArrowRight/Left: navigate between segments
+  - Number keys: type-ahead with 800ms buffer, auto-advance on full entry
+  - Backspace: clear segment back to placeholder
+- Hidden `<input>` syncs combined ISO 8601 value when all segments are filled
+- Dispatches `change` event on the controller element
+
+## Key Design Decisions
+
+- **No Cally dependency** — pure Stimulus, no web components. The segmented
+  input is a standalone component that doesn't need a calendar grid.
+- **MM/DD/YYYY format** — US locale default. Future: locale-aware segment
+  ordering (DD/MM/YYYY for EU).
+- **`tabular-nums` on segments** — prevents layout shift as digits change.
+- **`focus:bg-primary focus:text-primary-foreground`** — focused segment
+  uses the primary color, matching the calendar's selected-date styling.
+
+## Files
+
+- `lib/kiso/themes/input_date.rb`
+- `app/views/kiso/components/_input_date.html.erb`
+- `app/javascript/controllers/kiso/input_date_controller.js`

--- a/skills/kiso/references/components.md
+++ b/skills/kiso/references/components.md
@@ -37,6 +37,9 @@ All colored components use **identical compound variant formulas** — see `proj
 | `combobox` | `name`, `multiple`. Sub-parts: input, content, list, item, empty, group, label, separator, chips, chip, chips_input. Stimulus: `kiso--combobox` | [combobox.md](components/combobox.md) |
 | `select` | `name`, `size` (sm/md). Sub-parts: trigger, value, content, group, label, item, separator. Stimulus: `kiso--select` | [select.md](components/select.md) |
 | `switch` | `color` (7 colors), `size` (sm/md), `checked` | [switch.md](components/switch.md) |
+| `calendar` | `mode` (single/range), `color` (7 colors), `variant` (solid/outline/soft/subtle), `size` (sm/md/lg), `months`. Wraps Cally web components. | calendar |
+| `date_picker` | `name`, `value`, `color`, `variant`, `min`, `max`, `months`, `mode`. Composes Button + Popover + Calendar. Stimulus: `kiso--date-picker` | date_picker |
+| `input_date` | `name`, `value`, `variant` (outline/soft/ghost), `size` (sm/md/lg). Segmented MM/DD/YYYY input. Stimulus: `kiso--input-date` | input_date |
 
 ## Overlay
 

--- a/test/components/previews/kiso/calendar_preview.rb
+++ b/test/components/previews/kiso/calendar_preview.rb
@@ -1,0 +1,37 @@
+module Kiso
+  # @label Calendar
+  # @logical_path kiso/date
+  class CalendarPreview < Lookbook::Preview
+    # @label Playground
+    # @param color select { choices: [primary, secondary, success, info, warning, error, neutral] }
+    # @param variant select { choices: [solid, outline, soft, subtle] }
+    # @param size select { choices: [sm, md, lg] }
+    def playground(color: :primary, variant: :solid, size: :md)
+      render_with_template(locals: {
+        color: color.to_sym,
+        variant: variant.to_sym,
+        size: size.to_sym
+      })
+    end
+
+    # @label Colors
+    def colors
+      render_with_template
+    end
+
+    # @label Variants
+    def variants
+      render_with_template
+    end
+
+    # @label Range Selection
+    def range
+      render_with_template
+    end
+
+    # @label Multiple Months
+    def multiple_months
+      render_with_template
+    end
+  end
+end

--- a/test/components/previews/kiso/calendar_preview/colors.html.erb
+++ b/test/components/previews/kiso/calendar_preview/colors.html.erb
@@ -1,0 +1,10 @@
+<%= javascript_import_module_tag "cally" %>
+
+<div class="flex flex-wrap gap-6 p-4">
+  <% %i[primary secondary success info warning error neutral].each do |color| %>
+    <div class="flex flex-col gap-2">
+      <span class="text-sm font-medium text-foreground"><%= color %></span>
+      <%= kui(:calendar, color: color, value: Date.today.iso8601) %>
+    </div>
+  <% end %>
+</div>

--- a/test/components/previews/kiso/calendar_preview/multiple_months.html.erb
+++ b/test/components/previews/kiso/calendar_preview/multiple_months.html.erb
@@ -1,0 +1,5 @@
+<%= javascript_import_module_tag "cally" %>
+
+<div class="flex flex-col gap-4 p-4">
+  <%= kui(:calendar, months: 3, value: Date.today.iso8601) %>
+</div>

--- a/test/components/previews/kiso/calendar_preview/playground.html.erb
+++ b/test/components/previews/kiso/calendar_preview/playground.html.erb
@@ -1,0 +1,5 @@
+<%= javascript_import_module_tag "cally" %>
+
+<div class="flex flex-col gap-4 p-4">
+  <%= kui(:calendar, color: color, variant: variant, size: size, value: Date.today.iso8601) %>
+</div>

--- a/test/components/previews/kiso/calendar_preview/range.html.erb
+++ b/test/components/previews/kiso/calendar_preview/range.html.erb
@@ -1,0 +1,6 @@
+<%= javascript_import_module_tag "cally" %>
+
+<div class="flex flex-col gap-4 p-4">
+  <span class="text-sm text-muted-foreground">Click two dates to select a range</span>
+  <%= kui(:calendar, mode: :range, months: 2) %>
+</div>

--- a/test/components/previews/kiso/calendar_preview/variants.html.erb
+++ b/test/components/previews/kiso/calendar_preview/variants.html.erb
@@ -1,0 +1,10 @@
+<%= javascript_import_module_tag "cally" %>
+
+<div class="flex flex-wrap gap-6 p-4">
+  <% %i[solid outline soft subtle].each do |variant| %>
+    <div class="flex flex-col gap-2">
+      <span class="text-sm font-medium text-foreground"><%= variant %></span>
+      <%= kui(:calendar, variant: variant, value: Date.today.iso8601) %>
+    </div>
+  <% end %>
+</div>

--- a/test/components/previews/kiso/date_picker_preview.rb
+++ b/test/components/previews/kiso/date_picker_preview.rb
@@ -1,0 +1,25 @@
+module Kiso
+  # @label Date Picker
+  # @logical_path kiso/date
+  class DatePickerPreview < Lookbook::Preview
+    # @label Playground
+    # @param color select { choices: [primary, secondary, success, info, warning, error, neutral] }
+    # @param variant select { choices: [solid, outline, soft, subtle] }
+    def playground(color: :primary, variant: :solid)
+      render_with_template(locals: {
+        color: color.to_sym,
+        variant: variant.to_sym
+      })
+    end
+
+    # @label With Value
+    def with_value
+      render_with_template
+    end
+
+    # @label In a Form
+    def in_a_form
+      render_with_template
+    end
+  end
+end

--- a/test/components/previews/kiso/date_picker_preview/in_a_form.html.erb
+++ b/test/components/previews/kiso/date_picker_preview/in_a_form.html.erb
@@ -1,0 +1,16 @@
+<div class="max-w-md p-4">
+  <form action="#" method="post" class="flex flex-col gap-4">
+    <%= kui(:field) do %>
+      <%= kui(:field, :label) { "Event Date" } %>
+      <%= kui(:date_picker, name: "event[date]", required: true, placeholder: "Select event date") %>
+      <%= kui(:field, :description) { "Choose when the event should take place." } %>
+    <% end %>
+
+    <%= kui(:field) do %>
+      <%= kui(:field, :label) { "Event Name" } %>
+      <%= kui(:input, name: "event[name]", placeholder: "Enter event name") %>
+    <% end %>
+
+    <%= kui(:button, type: "submit") { "Create Event" } %>
+  </form>
+</div>

--- a/test/components/previews/kiso/date_picker_preview/playground.html.erb
+++ b/test/components/previews/kiso/date_picker_preview/playground.html.erb
@@ -1,0 +1,3 @@
+<div class="flex flex-col gap-4 p-4">
+  <%= kui(:date_picker, color: color, variant: variant, name: "event_date") %>
+</div>

--- a/test/components/previews/kiso/date_picker_preview/with_value.html.erb
+++ b/test/components/previews/kiso/date_picker_preview/with_value.html.erb
@@ -1,0 +1,4 @@
+<div class="flex flex-col gap-4 p-4">
+  <span class="text-sm text-muted-foreground">Pre-selected date</span>
+  <%= kui(:date_picker, value: Date.today.iso8601, name: "start_date") %>
+</div>

--- a/test/components/previews/kiso/input_date_preview.rb
+++ b/test/components/previews/kiso/input_date_preview.rb
@@ -1,0 +1,30 @@
+module Kiso
+  # @label Input Date
+  # @logical_path kiso/date
+  class InputDatePreview < Lookbook::Preview
+    # @label Playground
+    # @param variant select { choices: [outline, soft, ghost] }
+    # @param size select { choices: [sm, md, lg] }
+    def playground(variant: :outline, size: :md)
+      render_with_template(locals: {
+        variant: variant.to_sym,
+        size: size.to_sym
+      })
+    end
+
+    # @label With Value
+    def with_value
+      render_with_template
+    end
+
+    # @label Sizes
+    def sizes
+      render_with_template
+    end
+
+    # @label In a Form
+    def in_a_form
+      render_with_template
+    end
+  end
+end

--- a/test/components/previews/kiso/input_date_preview/in_a_form.html.erb
+++ b/test/components/previews/kiso/input_date_preview/in_a_form.html.erb
@@ -1,0 +1,11 @@
+<div class="max-w-md p-4">
+  <form action="#" method="post" class="flex flex-col gap-4">
+    <%= kui(:field) do %>
+      <%= kui(:field, :label) { "Birth Date" } %>
+      <%= kui(:input_date, name: "person[birth_date]", required: true) %>
+      <%= kui(:field, :description) { "Enter your date of birth." } %>
+    <% end %>
+
+    <%= kui(:button, type: "submit") { "Save" } %>
+  </form>
+</div>

--- a/test/components/previews/kiso/input_date_preview/playground.html.erb
+++ b/test/components/previews/kiso/input_date_preview/playground.html.erb
@@ -1,0 +1,4 @@
+<div class="flex flex-col gap-4 p-4">
+  <span class="text-sm text-muted-foreground">Click a segment, then use arrow keys or type numbers</span>
+  <%= kui(:input_date, variant: variant, size: size, name: "date") %>
+</div>

--- a/test/components/previews/kiso/input_date_preview/sizes.html.erb
+++ b/test/components/previews/kiso/input_date_preview/sizes.html.erb
@@ -1,0 +1,8 @@
+<div class="flex flex-col gap-4 p-4">
+  <% %i[sm md lg].each do |size| %>
+    <div class="flex items-center gap-4">
+      <span class="text-sm font-medium text-foreground w-8"><%= size %></span>
+      <%= kui(:input_date, size: size, value: "2026-03-15", name: "date_#{size}") %>
+    </div>
+  <% end %>
+</div>

--- a/test/components/previews/kiso/input_date_preview/with_value.html.erb
+++ b/test/components/previews/kiso/input_date_preview/with_value.html.erb
@@ -1,0 +1,4 @@
+<div class="flex flex-col gap-4 p-4">
+  <span class="text-sm text-muted-foreground">Pre-filled with today's date</span>
+  <%= kui(:input_date, value: Date.today.iso8601, name: "date") %>
+</div>


### PR DESCRIPTION
## Summary

WIP implementation of three date components wrapping [Cally](https://wicky.nillia.ms/cally/) web components. Closes #95

- **`kui(:calendar)`** — standalone date grid, 7 colors × 4 variants, range mode, multi-month
- **`kui(:date_picker)`** — button trigger + native `[popover]` + Floating UI + calendar
- **`kui(:input_date)`** — segmented MM/DD/YYYY with full keyboard navigation

### Architecture

- Cally vendored as single 38KB ESM file (includes Atomico runtime)
- `::part()` CSS selectors for Shadow DOM styling with Kiso semantic tokens
- Stimulus controllers: `kiso--calendar` (theme bridge), `kiso--date-picker` (popover + value sync), `kiso--input-date` (keyboard segments)

### Key Technical Findings

- Cally dispatches `change` with `bubbles: false` — requires `customElements.whenDefined()` + direct listener
- Cally's `:host` declares `--color-accent: black` — cannot override from CSS outside Shadow DOM, requires JS controller to bridge tokens
- Native `[popover]` needs `inset: unset` + `position: fixed` for Floating UI

### Still Needs

- [ ] Nav button border cleanup (thin borders around chevron icons)
- [ ] Popover flicker on open
- [ ] Closer match to shadcn reference styling (spacing, cell sizing)
- [ ] E2E tests
- [ ] Dark mode verification for date picker popover

## Test plan

- [ ] Visual check in Lookbook (all previews under Date group)
- [ ] Calendar: single select, range select, multi-month, all 7 colors, all 4 variants
- [ ] Date Picker: open popover, select date, verify hidden input value, popover closes
- [ ] Input Date: arrow keys, number typing, tab between segments, verify ISO value
- [ ] Dark mode toggle on all three components
- [ ] `bundle exec rake test` passes
- [ ] `npm run lint && npm run fmt:check` clean