### PR TITLE
feat: Auto-apply body base styles via @layer base

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,10 @@ And add the dark mode helper to your layout's `<head>`:
   <%= stylesheet_link_tag "tailwind" %>
   <%= javascript_importmap_tags %>
 </head>
-
-<body class="bg-background text-foreground antialiased">
 ```
 
-That's it. Helpers, importmap pins, asset paths, and dark mode tokens are all
-wired up automatically by the engine. See the
+That's it. Helpers, importmap pins, asset paths, dark mode tokens, and base
+body styles are all wired up automatically by the engine. See the
 [Getting Started guide](https://kisoui.com/getting-started) for the full
 walkthrough.
 

--- a/app/assets/tailwind/kiso/engine.css
+++ b/app/assets/tailwind/kiso/engine.css
@@ -133,3 +133,16 @@
 
   --color-ring: var(--color-zinc-600);
 }
+
+/* === Page Defaults ===
+   Kiso automatically applies sensible base styles to <body> so host apps
+   start with the correct colors and rendering. Uses @layer base (lowest
+   Tailwind priority) — utility classes on <body> override automatically. */
+
+@layer base {
+  body {
+    @apply bg-background text-foreground antialiased;
+    font-synthesis-weight: none;
+    text-rendering: optimizeLegibility;
+  }
+}

--- a/docs/src/_layouts/default.erb
+++ b/docs/src/_layouts/default.erb
@@ -3,7 +3,7 @@
   <head>
     <%= render "head", metadata: site.metadata, title: data.title %>
   </head>
-  <body class="min-h-screen bg-background text-foreground antialiased">
+  <body class="min-h-screen">
     <%= yield %>
   </body>
 </html>

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -59,22 +59,24 @@ A minimal layout that works with Kiso and dark mode:
     <%%= javascript_importmap_tags %>
   </head>
 
-  <body class="bg-background text-foreground antialiased">
+  <body>
     <%%= yield %>
   </body>
 </html>
 ```
 
-Three things to note:
+Two things to note:
 
 - **`kiso_theme_script`** outputs a blocking inline script that reads the
   user's theme preference (localStorage, cookie, or OS setting) and sets
   `.dark` on `<html>` before first paint. No server-side code needed.
-- **`bg-background text-foreground`** on `<body>` sets the base colors using
-  Kiso's semantic tokens. These switch automatically in dark mode.
 - **`javascript_importmap_tags`** loads Stimulus controllers. Kiso's
   controllers (for interactive components like Select, Combobox, etc.) are
   registered automatically via the engine.
+
+Kiso automatically applies `bg-background text-foreground antialiased` to
+`<body>` via `@layer base`, so you don't need to add those classes yourself.
+The base colors switch automatically in dark mode.
 
 ## Your first component
 

--- a/docs/src/guide/dark-mode.md
+++ b/docs/src/guide/dark-mode.md
@@ -73,17 +73,17 @@ brand:
 Every component that uses `bg-primary` or `text-primary` will pick up your
 overrides automatically.
 
-## Setting `text-foreground`
+## Base body styles
 
-One thing to know: the browser's default text color is black and doesn't
-change when `.dark` is applied. Kiso components set `text-foreground` on
-their root element so all children inherit the correct color in both modes.
+Kiso automatically applies `bg-background text-foreground antialiased` to
+`<body>` via `@layer base`. You don't need to add these classes manually —
+they switch automatically when `.dark` is toggled.
 
-If you're building custom layouts around Kiso components, set
-`text-foreground` on your own container elements too:
+If you're building custom containers with their own background color,
+set `text-foreground` on them so children inherit the correct text color:
 
 ```erb
-<div class="bg-background text-foreground">
+<div class="bg-muted text-foreground">
   <%% # Children will inherit correct text color in dark mode %>
 </div>
 ```

--- a/lookbook/app/views/layouts/preview.html.erb
+++ b/lookbook/app/views/layouts/preview.html.erb
@@ -16,7 +16,7 @@
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
-  <body class="p-8 bg-background antialiased" style="text-rendering: optimizeLegibility; font-synthesis-weight: none;">
+  <body class="p-8">
     <%= yield %>
   </body>
 </html>

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
-  <body class="bg-background text-foreground antialiased">
+  <body>
     <%= yield %>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- Add `@layer base { body { ... } }` rule to `engine.css` with `bg-background text-foreground antialiased` plus `font-synthesis-weight` and `text-rendering` for sharper typography
- Remove redundant body classes from all internal layouts (dummy app, Lookbook, docs site)
- Update Getting Started guide, Dark Mode guide, and README to reflect the automatic behavior

Host apps no longer need to manually add `bg-background text-foreground antialiased` to `<body>`. The `@layer base` placement means utility classes on `<body>` still override automatically (utilities > base layer).

Closes #131

## Test plan

- [x] `bundle exec rake test` — all pass
- [x] `bundle exec standardrb` — clean
- [x] `npm run lint && npm run fmt:check` — clean
- [x] Built CSS contains correct `body { ... }` rule with all 6 properties
- [ ] Visual check: Lookbook previews render correctly (light + dark)
- [ ] Visual check: dummy app dashboard layout still works (already had bare `<body>`)