### PR TITLE
fix: Align sidebar header/footer with shadcn flex-col layout

### DIFF
--- a/lib/kiso/themes/dashboard.rb
+++ b/lib/kiso/themes/dashboard.rb
@@ -21,11 +21,11 @@ module Kiso
     )
 
     DashboardSidebarHeader = ClassVariants.build(
-      base: "shrink-0 flex items-center gap-1.5 px-4"
+      base: "shrink-0 flex flex-col gap-2 p-2"
     )
 
     DashboardSidebarFooter = ClassVariants.build(
-      base: "shrink-0 flex items-center gap-1.5 px-4 py-2"
+      base: "shrink-0 flex flex-col gap-2 p-2"
     )
 
     DashboardSidebarToggle = ClassVariants.build(

--- a/test/components/previews/kiso/dashboard_group_preview/custom_toggle_icons.html.erb
+++ b/test/components/previews/kiso/dashboard_group_preview/custom_toggle_icons.html.erb
@@ -16,10 +16,12 @@
 
     <%= kui(:dashboard_sidebar) do %>
       <%= kui(:dashboard_sidebar, :header) do %>
-        <div class="flex items-center justify-center w-6 h-6 rounded-md bg-primary shrink-0">
-          <%= kiso_icon("layers", class: "size-3.5 text-primary-foreground") %>
+        <div class="flex items-center gap-1.5">
+          <div class="flex items-center justify-center w-6 h-6 rounded-md bg-primary shrink-0">
+            <%= kiso_icon("layers", class: "size-3.5 text-primary-foreground") %>
+          </div>
+          <span class="font-semibold text-sm truncate">Kiso App</span>
         </div>
-        <span class="font-semibold text-sm truncate">Kiso App</span>
       <% end %>
       <%= kui(:nav) do %>
         <%= kui(:nav, :section, title: "Main") do %>

--- a/test/components/previews/kiso/dashboard_group_preview/playground.html.erb
+++ b/test/components/previews/kiso/dashboard_group_preview/playground.html.erb
@@ -18,10 +18,12 @@
 
     <%= kui(:dashboard_sidebar) do %>
       <%= kui(:dashboard_sidebar, :header) do %>
-        <div class="flex items-center justify-center w-6 h-6 rounded-md bg-primary shrink-0">
-          <%= kiso_icon("layers", class: "size-3.5 text-primary-foreground") %>
+        <div class="flex items-center gap-1.5">
+          <div class="flex items-center justify-center w-6 h-6 rounded-md bg-primary shrink-0">
+            <%= kiso_icon("layers", class: "size-3.5 text-primary-foreground") %>
+          </div>
+          <span class="font-semibold text-sm truncate">Kiso App</span>
         </div>
-        <span class="font-semibold text-sm truncate">Kiso App</span>
       <% end %>
       <%= kui(:nav, css_classes: "flex-1 overflow-y-auto") do %>
         <%= kui(:nav, :section, title: "Main") do %>

--- a/test/components/previews/kiso/dashboard_group_preview/sidebar_closed.html.erb
+++ b/test/components/previews/kiso/dashboard_group_preview/sidebar_closed.html.erb
@@ -12,10 +12,12 @@
 
     <%= kui(:dashboard_sidebar) do %>
       <%= kui(:dashboard_sidebar, :header) do %>
-        <div class="flex items-center justify-center w-6 h-6 rounded-md bg-primary shrink-0">
-          <%= kiso_icon("layers", class: "size-3.5 text-primary-foreground") %>
+        <div class="flex items-center gap-1.5">
+          <div class="flex items-center justify-center w-6 h-6 rounded-md bg-primary shrink-0">
+            <%= kiso_icon("layers", class: "size-3.5 text-primary-foreground") %>
+          </div>
+          <span class="font-semibold text-sm truncate">Kiso App</span>
         </div>
-        <span class="font-semibold text-sm truncate">Kiso App</span>
       <% end %>
       <%= kui(:nav) do %>
         <%= kui(:nav, :section) do %>


### PR DESCRIPTION
## Summary

- Change `DashboardSidebarHeader` and `DashboardSidebarFooter` from `flex items-center gap-1.5` (horizontal) to `flex flex-col gap-2 p-2` (vertical), matching shadcn's sidebar implementation
- Wrap horizontal content in preview templates with their own flex row containers

The previous horizontal default forced workarounds like `css_classes: "flex-col items-stretch"` for stacked footer content (theme select + sign-out link). Now the container stacks children vertically and each row manages its own layout.

Closes #142