### PR TITLE
feat: Add method: prop to Button for form actions

### DIFF
--- a/app/views/kiso/components/_button.html.erb
+++ b/app/views/kiso/components/_button.html.erb
@@ -1,19 +1,33 @@
 <%# locals: (color: :primary, variant: :solid, size: :md, block: false,
-             type: :button, href: nil, disabled: false,
-             css_classes: "", **component_options) %>
-<% tag_name = href.present? ? :a : :button
-   if tag_name == :a
-     component_options[:href] = href
-     component_options[:"aria-disabled"] = true if disabled
-   else
-     component_options[:type] = type
-     component_options[:disabled] = true if disabled
-   end %>
-<%= content_tag tag_name,
-    class: Kiso::Themes::Button.render(
-      color: color, variant: variant, size: size, block: block,
-      class: css_classes),
-    data: kiso_prepare_options(component_options, slot: "button"),
-    **component_options do %>
-  <%= yield %>
+             type: :button, href: nil, method: nil, disabled: false,
+             form: {}, css_classes: "", **component_options) %>
+<%
+  css = Kiso::Themes::Button.render(
+    color: color, variant: variant, size: size, block: block, class: css_classes)
+  data = kiso_prepare_options(component_options, slot: "button")
+  use_button_to = href.present? && method.present? && method.to_s != "get"
+%>
+<% if use_button_to %>
+  <%= button_to href,
+      method: method,
+      class: css,
+      form_class: "contents",
+      data: data,
+      disabled: disabled || nil,
+      form: form.presence,
+      **component_options do %>
+    <%= yield %>
+  <% end %>
+<% elsif href.present? %>
+  <% component_options[:href] = href
+     component_options[:"aria-disabled"] = true if disabled %>
+  <%= content_tag :a, class: css, data: data, **component_options do %>
+    <%= yield %>
+  <% end %>
+<% else %>
+  <% component_options[:type] = type
+     component_options[:disabled] = true if disabled %>
+  <%= content_tag :button, class: css, data: data, **component_options do %>
+    <%= yield %>
+  <% end %>
 <% end %>

--- a/docs/src/components/button.md
+++ b/docs/src/components/button.md
@@ -25,6 +25,8 @@ source: lib/kiso/themes/button.rb
 | `disabled:` | `Boolean` | `false` |
 | `type:` | `:button` \| `:submit` \| `:reset` | `:button` |
 | `href:` | `String` \| `nil` | `nil` |
+| `method:` | `:delete` \| `:post` \| `:put` \| `:patch` \| `nil` | `nil` |
+| `form:` | `Hash` | `{}` |
 | `css_classes:` | `String` | `""` |
 | `**component_options` | `Hash` | `{}` |
 
@@ -68,7 +70,9 @@ compound variant formulas. Ghost and link are Button-only additions.
 
 ### Smart Tag
 
-When `href:` is present, renders `<a>` instead of `<button>`.
+When `href:` is present, renders `<a>` instead of `<button>`. When `method:`
+is also present (e.g. `:delete`, `:post`), renders via Rails `button_to` —
+wrapping the styled button in a `<form>` for non-GET HTTP methods.
 
 ```erb
 <%%# Renders <button> %>
@@ -76,6 +80,9 @@ When `href:` is present, renders `<a>` instead of `<button>`.
 
 <%%# Renders <a href="/settings"> %>
 <%%= kui(:button, href: "/settings") { "Settings" } %>
+
+<%%# Renders <form> + <button> via button_to %>
+<%%= kui(:button, href: session_path, method: :delete) { "Sign out" } %>
 ```
 
 ### Disabled
@@ -117,6 +124,43 @@ size via `[&_svg:not([class*='size-'])]:size-4`.
   Add Item
 <%% end %>
 ```
+
+### Form Method (button_to)
+
+For destructive or state-changing actions that need non-GET HTTP methods
+(sign out, delete, archive), pass `method:` along with `href:`. This renders
+via Rails `button_to`, wrapping the button in a `<form>` with a hidden
+`_method` field. The form uses `display: contents` so it's invisible to
+flex/grid layout.
+
+```erb
+<%%= kui(:button, href: session_path, method: :delete, variant: :ghost) do %>
+  <%%= kiso_icon("log-out") %> Sign out
+<%% end %>
+
+<%%= kui(:button, href: post_path(@post), method: :delete, color: :error) do %>
+  <%%= kiso_icon("trash-2") %> Delete
+<%% end %>
+```
+
+Works with Turbo confirm — `data-turbo-confirm` goes on the `<button>`:
+
+```erb
+<%%= kui(:button, href: post_path(@post), method: :delete,
+    color: :error, data: { turbo_confirm: "Are you sure?" }) { "Delete" } %>
+```
+
+For form-level attributes (e.g. Turbo Frame targeting), use `form:`:
+
+```erb
+<%%= kui(:button, href: archive_path, method: :post,
+    form: { data: { turbo_frame: "_top" } }) { "Archive" } %>
+```
+
+**Note:** Do not place a `method:` button inside an existing `<form>` — this
+creates invalid nested forms (same limitation as raw `button_to`). For full
+control over the form wrapper, use `button_to` directly with
+`Kiso::Themes::Button.render(...)` for styling.
 
 ## Examples
 

--- a/skills/kiso/references/components.md
+++ b/skills/kiso/references/components.md
@@ -69,7 +69,7 @@ All colored components use **identical compound variant formulas** — see `proj
 |---|---|---|
 | `alert` | `color`, `variant` (solid/outline/soft/subtle) | [alert.md](components/alert.md) |
 | `badge` | `color`, `variant` (solid/outline/soft/subtle), `size` (xs-xl) | [badge.md](components/badge.md) |
-| `button` | `color`, `variant` (solid/outline/soft/subtle/ghost/link), `size` (xs-xl) | [button.md](components/button.md) |
+| `button` | `color`, `variant` (solid/outline/soft/subtle/ghost/link), `size` (xs-xl), `method:` (delete/post/put/patch), `form:` | [button.md](components/button.md) |
 | `color_mode_button` | `size` (sm/md/lg). Toggles light/dark via `kiso--theme#toggle`. Icons: `kiso_component_icon(:sun/:moon)` | [color_mode_button.md](components/color_mode_button.md) |
 | `color_mode_select` | `size` (sm/md). Three-way select (light/dark/system). Composes `kui(:select)`, dispatches to `kiso--theme#set` | [color_mode_select.md](components/color_mode_select.md) |
 | `kbd` | `size` (sm/md/lg). Sub-part: group | [kbd.md](components/kbd.md) |

--- a/skills/kiso/references/components/button.md
+++ b/skills/kiso/references/components/button.md
@@ -1,9 +1,9 @@
 # Button
 
 Interactive button with smart tag selection. Renders `<button>` by default,
-`<a>` when `href:` is present.
+`<a>` when `href:` is present, `button_to` (form) when `method:` is present.
 
-**Locals:** `color:`, `variant:` (solid, outline, soft, subtle, ghost, link), `size:` (xs-xl), `block:` (true/false), `disabled:` (true/false), `type:` (button, submit, reset), `href:` (string), `css_classes:`, `**component_options`
+**Locals:** `color:`, `variant:` (solid, outline, soft, subtle, ghost, link), `size:` (xs-xl), `block:` (true/false), `disabled:` (true/false), `type:` (button, submit, reset), `href:` (string), `method:` (delete, post, put, patch), `form:` (hash), `css_classes:`, `**component_options`
 
 **Defaults:** `color: :primary, variant: :solid, size: :md`
 
@@ -16,9 +16,24 @@ Interactive button with smart tag selection. Renders `<button>` by default,
 
 <%# With inline icon %>
 <%= kui(:button, variant: :outline) do %>
-  <svg class="size-4">...</svg>
+  <%= kiso_icon("download") %>
   Download
 <% end %>
+
+<%# DELETE via button_to (generates <form> + <button>) %>
+<%= kui(:button, href: session_path, method: :delete, variant: :ghost) do %>
+  <%= kiso_icon("log-out") %> Sign out
+<% end %>
+
+<%# With turbo confirm %>
+<%= kui(:button, href: post_path(@post), method: :delete,
+    color: :error, data: { turbo_confirm: "Are you sure?" }) { "Delete" } %>
+
+<%# Form-level attributes %>
+<%= kui(:button, href: archive_path, method: :post,
+    form: { data: { turbo_frame: "_top" } }) { "Archive" } %>
 ```
+
+**Smart tag:** `href:` + `method:` (non-GET) → `button_to` with `form_class: "contents"`. `href:` alone → `<a>`. No `href:` → `<button>`. Do not nest inside an existing `<form>`.
 
 **Theme module:** `Kiso::Themes::Button` (`lib/kiso/themes/button.rb`)

--- a/test/components/previews/kiso/button_preview.rb
+++ b/test/components/previews/kiso/button_preview.rb
@@ -53,5 +53,17 @@ module Kiso
     def disabled
       render_with_template
     end
+
+    # @label Form Method
+    # @param method select { choices: [delete, post, put, patch] }
+    # @param variant select { choices: [solid, outline, soft, subtle, ghost, link] }
+    # @param color select { choices: [primary, secondary, success, info, warning, error, neutral] }
+    def form_method(method: :delete, variant: :ghost, color: :neutral)
+      render_with_template(locals: {
+        method: method.to_sym,
+        variant: variant.to_sym,
+        color: color.to_sym
+      })
+    end
   end
 end

--- a/test/components/previews/kiso/button_preview/form_method.html.erb
+++ b/test/components/previews/kiso/button_preview/form_method.html.erb
@@ -1,0 +1,30 @@
+<%# Buttons that use Rails button_to for non-GET HTTP methods.
+    The form wrapper uses display:contents — invisible to layout. %>
+<div class="space-y-4">
+  <p class="text-sm text-muted-foreground">Configurable (inspect source to see the form wrapper)</p>
+  <div class="flex flex-wrap gap-3 items-center">
+    <%= kui(:button, href: "#", method: method, variant: variant, color: color) do %>
+      <%= kiso_icon("log-out") %> Sign out
+    <% end %>
+  </div>
+
+  <p class="text-sm text-muted-foreground">Common patterns</p>
+  <div class="flex flex-wrap gap-3 items-center">
+    <%= kui(:button, href: "#", method: :delete, variant: :ghost, color: :neutral) do %>
+      <%= kiso_icon("log-out") %> Sign out
+    <% end %>
+    <%= kui(:button, href: "#", method: :post, variant: :outline) do %>
+      <%= kiso_icon("archive") %> Archive
+    <% end %>
+    <%= kui(:button, href: "#", method: :delete, color: :error) do %>
+      <%= kiso_icon("trash-2") %> Delete
+    <% end %>
+  </div>
+
+  <p class="text-sm text-muted-foreground">Disabled</p>
+  <div class="flex flex-wrap gap-3 items-center">
+    <%= kui(:button, href: "#", method: :delete, variant: :outline, color: :error, disabled: true) do %>
+      <%= kiso_icon("trash-2") %> Delete
+    <% end %>
+  </div>
+</div>

--- a/test/e2e/components/button.spec.js
+++ b/test/e2e/components/button.spec.js
@@ -54,6 +54,33 @@ test.describe("Button component", () => {
     await expect(page.locator("button[data-slot='button']").first()).toBeDisabled()
   })
 
+  test.describe("form method", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(`${BASE}/form_method`)
+    })
+
+    test("renders form with class=contents when method is present", async ({ page }) => {
+      const form = page.locator("form.contents").first()
+      await expect(form).toBeAttached()
+    })
+
+    test("form contains hidden _method input", async ({ page }) => {
+      const hidden = page.locator("form.contents input[name='_method']").first()
+      await expect(hidden).toHaveAttribute("value", "delete")
+    })
+
+    test("inner button has data-slot and theme classes", async ({ page }) => {
+      const button = page.locator("form.contents button[data-slot='button']").first()
+      await expect(button).toBeVisible()
+      await expect(button).toHaveAttribute("type", "submit")
+    })
+
+    test("disabled button inside form", async ({ page }) => {
+      const button = page.locator("form.contents button[disabled]")
+      await expect(button).toBeVisible()
+    })
+  })
+
   test("passes WCAG 2.1 AA", async ({ page, checkA11y }) => {
     await page.goto(`${BASE}/playground`)
     const results = await checkA11y()


### PR DESCRIPTION
## Summary

- Add `method:` and `form:` locals to the Button component
- When `method:` is present with `href:` (non-GET), renders via `button_to` instead of `content_tag`
- Form wrapper uses `form_class: "contents"` (invisible to flex/grid layout)
- `form:` hash passes through to `button_to` for form-level attributes (e.g. `data-turbo-frame`)
- Theme classes, `data-slot`, and all component options land on the inner `<button>`

Smart tag now has three paths:
1. `href:` + `method:` (non-GET) → `button_to`
2. `href:` alone → `<a>`
3. no `href:` → `<button>`

```erb
<%= kui(:button, href: session_path, method: :delete, variant: :ghost) do %>
  <%= kiso_icon("log-out") %> Sign out
<% end %>
```

## Test plan

- [x] E2E: 4 new tests for form rendering, hidden _method input, data-slot, disabled
- [x] All 14 button E2E tests pass
- [x] Lookbook preview: form_method scenario with DELETE/POST/disabled variants
- [x] Ruby lint clean, JS lint clean
- [x] Docs and skill references updated

Closes #141