### PR TITLE
feat: Add :actions slot to empty component

### DIFF
--- a/app/views/kiso/components/empty/_actions.html.erb
+++ b/app/views/kiso/components/empty/_actions.html.erb
@@ -1,0 +1,7 @@
+<%# locals: (css_classes: "", **component_options) %>
+<%= content_tag :div,
+    class: Kiso::Themes::EmptyActions.render(class: css_classes),
+    data: kiso_prepare_options(component_options, slot: "empty-actions"),
+    **component_options do %>
+  <%= yield %>
+<% end %>

--- a/docs/src/components/empty.md
+++ b/docs/src/components/empty.md
@@ -39,7 +39,8 @@ The root `empty` has no variant axis — it renders a centered flex container.
 | `:media` | `kui(:empty, :media)` | Icon or image container |
 | `:title` | `kui(:empty, :title)` | Heading text |
 | `:description` | `kui(:empty, :description)` | Muted description text |
-| `:content` | `kui(:empty, :content)` | Action area (buttons, links) |
+| `:actions` | `kui(:empty, :actions)` | Centered button group for CTAs |
+| `:content` | `kui(:empty, :content)` | General content area (inputs, links) |
 
 All sub-parts accept `css_classes:` and `**component_options`.
 
@@ -51,7 +52,8 @@ Empty
 │   ├── Media (icon or image)
 │   ├── Title
 │   └── Description
-└── Content (actions)
+├── Actions (CTA buttons)
+└── Content (general content)
 ```
 
 All sub-parts are optional. Use any combination.
@@ -79,7 +81,9 @@ The `:media` sub-part has a `variant:` local to control how icons are displayed.
 
 ### With Actions
 
-Use the `:content` sub-part for buttons and links below the header.
+Use the `:actions` sub-part for call-to-action buttons below the header.
+Buttons are automatically centered with `gap-2` spacing and wrap on narrow
+screens.
 
 ```erb
 <%%= kui(:empty) do %>
@@ -90,11 +94,9 @@ Use the `:content` sub-part for buttons and links below the header.
     <%%= kui(:empty, :title) { "No Projects Yet" } %>
     <%%= kui(:empty, :description) { "Get started by creating your first project." } %>
   <%% end %>
-  <%%= kui(:empty, :content) do %>
-    <div class="flex gap-2">
-      <%%= kui(:button) { "Create Project" } %>
-      <%%= kui(:button, variant: :outline) { "Import Project" } %>
-    </div>
+  <%%= kui(:empty, :actions) do %>
+    <%%= kui(:button) { "Create Project" } %>
+    <%%= kui(:button, variant: :outline) { "Import Project" } %>
   <%% end %>
 <%% end %>
 ```
@@ -149,6 +151,7 @@ EmptyMedia       = ClassVariants.build(
 )
 EmptyTitle       = ClassVariants.build(base: "text-lg font-medium tracking-tight")
 EmptyDescription = ClassVariants.build(base: "text-muted-foreground text-sm/relaxed ...")
+EmptyActions     = ClassVariants.build(base: "flex flex-wrap items-center justify-center gap-2")
 EmptyContent     = ClassVariants.build(base: "flex w-full max-w-sm min-w-0 flex-col items-center gap-4 text-sm text-balance")
 ```
 

--- a/lib/kiso/themes/empty.rb
+++ b/lib/kiso/themes/empty.rb
@@ -9,7 +9,7 @@ module Kiso
     #   Empty.render
     #
     # Sub-parts: {EmptyHeader}, {EmptyMedia}, {EmptyTitle}, {EmptyDescription},
-    # {EmptyContent}
+    # {EmptyActions}, {EmptyContent}
     #
     # shadcn base: flex min-w-0 flex-1 flex-col ... border-dashed p-6 ... md:p-12
     Empty = ClassVariants.build(
@@ -44,6 +44,11 @@ module Kiso
     # Empty state body text with automatic link styling.
     EmptyDescription = ClassVariants.build(
       base: "text-muted-foreground text-sm/relaxed [&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4"
+    )
+
+    # Centered button group for call-to-action buttons.
+    EmptyActions = ClassVariants.build(
+      base: "flex flex-wrap items-center justify-center gap-2"
     )
 
     # Container for action buttons or other interactive content.

--- a/skills/kiso/references/components/empty.md
+++ b/skills/kiso/references/components/empty.md
@@ -5,7 +5,7 @@ Composed from sub-parts like Card. No color axis.
 
 **Locals:** `css_classes:`, `**component_options`
 
-**Sub-parts:** `kui(:empty, :header)`, `kui(:empty, :media)`, `kui(:empty, :title)`, `kui(:empty, :description)`, `kui(:empty, :content)`
+**Sub-parts:** `kui(:empty, :header)`, `kui(:empty, :media)`, `kui(:empty, :title)`, `kui(:empty, :description)`, `kui(:empty, :actions)`, `kui(:empty, :content)`
 
 **Media variants:** `variant:` (default, icon) — `:icon` renders a muted rounded container for SVG icons.
 
@@ -18,10 +18,11 @@ Composed from sub-parts like Card. No color axis.
     <%= kui(:empty, :title) { "No Projects Yet" } %>
     <%= kui(:empty, :description) { "Get started by creating your first project." } %>
   <% end %>
-  <%= kui(:empty, :content) do %>
+  <%= kui(:empty, :actions) do %>
     <%= kui(:button) { "Create Project" } %>
+    <%= kui(:button, variant: :outline) { "Import Project" } %>
   <% end %>
 <% end %>
 ```
 
-**Theme modules:** `Kiso::Themes::Empty`, `EmptyHeader`, `EmptyMedia`, `EmptyTitle`, `EmptyDescription`, `EmptyContent` (`lib/kiso/themes/empty.rb`)
+**Theme modules:** `Kiso::Themes::Empty`, `EmptyHeader`, `EmptyMedia`, `EmptyTitle`, `EmptyDescription`, `EmptyActions`, `EmptyContent` (`lib/kiso/themes/empty.rb`)

--- a/test/components/previews/kiso/empty_preview/outline.html.erb
+++ b/test/components/previews/kiso/empty_preview/outline.html.erb
@@ -6,7 +6,7 @@
     <%= kui(:empty, :title) { "Upload Files" } %>
     <%= kui(:empty, :description) { "Drag and drop files here, or click to browse." } %>
   <% end %>
-  <%= kui(:empty, :content) do %>
+  <%= kui(:empty, :actions) do %>
     <%= kui(:button, variant: :outline, size: :sm) { "Browse Files" } %>
   <% end %>
 <% end %>

--- a/test/components/previews/kiso/empty_preview/with_actions.html.erb
+++ b/test/components/previews/kiso/empty_preview/with_actions.html.erb
@@ -6,10 +6,8 @@
     <%= kui(:empty, :title) { "No Projects Yet" } %>
     <%= kui(:empty, :description) { "You haven't created any projects yet. Get started by creating your first project." } %>
   <% end %>
-  <%= kui(:empty, :content) do %>
-    <div class="flex gap-2">
-      <%= kui(:button) { "Create Project" } %>
-      <%= kui(:button, variant: :outline) { "Import Project" } %>
-    </div>
+  <%= kui(:empty, :actions) do %>
+    <%= kui(:button) { "Create Project" } %>
+    <%= kui(:button, variant: :outline) { "Import Project" } %>
   <% end %>
 <% end %>

--- a/test/e2e/components/empty.spec.js
+++ b/test/e2e/components/empty.spec.js
@@ -34,11 +34,11 @@ test.describe("Empty component", () => {
     await expect(page.getByTestId("empty-media")).toBeVisible()
   })
 
-  test("renders content sub-part with actions", async ({ page }) => {
+  test("renders actions sub-part with buttons", async ({ page }) => {
     await page.goto(`${BASE}/with_actions`)
-    const content = page.getByTestId("empty-content")
-    await expect(content).toBeVisible()
-    await expect(content.locator("[data-slot='button']")).toHaveCount(2)
+    const actions = page.getByTestId("empty-actions")
+    await expect(actions).toBeVisible()
+    await expect(actions.locator("[data-slot='button']")).toHaveCount(2)
   })
 
   test("passes WCAG 2.1 AA", async ({ page, checkA11y }) => {


### PR DESCRIPTION
## Summary
- Add `EmptyActions` theme module with centered flex layout (`flex flex-wrap items-center justify-center gap-2`)
- Add `app/views/kiso/components/empty/_actions.html.erb` partial with `data-slot="empty-actions"`
- Update Lookbook previews (`with_actions`, `outline`) to use `:actions` instead of `:content` for CTA buttons
- Update docs page, skills reference, and E2E tests

Closes #146

## Test plan
- [x] All Lookbook previews return 200 (playground, with_icon, with_actions, outline, inside_card)
- [x] Docs page loads at /components/empty
- [x] `bundle exec standardrb --fix` passes
- [x] `npm run lint && npm run fmt:check` passes
- [x] `bundle exec rake test` passes (19 runs, 34 assertions, 0 failures)
- [x] E2E tests pass (7/7 including WCAG 2.1 AA)
- [ ] Visual review in Lookbook