### PR TITLE
feat: Slider component

### DIFF
--- a/app/assets/tailwind/kiso/engine.css
+++ b/app/assets/tailwind/kiso/engine.css
@@ -8,6 +8,7 @@
 @import "./color-mode.css";
 @import "./dashboard.css";
 @import "./input-otp.css";
+@import "./slider.css";
 
 /* Scan Kiso's own files so host apps don't need to know the gem's internals.
    Paths are relative to THIS file (app/assets/tailwind/kiso/engine.css).

--- a/app/assets/tailwind/kiso/slider.css
+++ b/app/assets/tailwind/kiso/slider.css
@@ -1,0 +1,27 @@
+@layer components {
+  /* Center the thumb over its left % position */
+  [data-slot="slider-thumb"] {
+    transform: translateX(-50%);
+    top: 50%;
+    margin-top: calc(-1 * var(--thumb-offset, 0.5rem));
+  }
+
+  /* Size-specific thumb offsets (half the thumb size) */
+  [data-slot="slider"] :where([data-slot="slider-thumb"].size-3) {
+    --thumb-offset: 0.375rem;
+  }
+
+  [data-slot="slider"] :where([data-slot="slider-thumb"].size-4) {
+    --thumb-offset: 0.5rem;
+  }
+
+  [data-slot="slider"] :where([data-slot="slider-thumb"].size-5) {
+    --thumb-offset: 0.625rem;
+  }
+
+  /* Disabled state */
+  [data-slot="slider"]:has(input:disabled) {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+}

--- a/app/javascript/controllers/kiso/slider_controller.js
+++ b/app/javascript/controllers/kiso/slider_controller.js
@@ -1,0 +1,276 @@
+import { Controller } from "@hotwired/stimulus"
+
+/**
+ * Connects a visual slider (track, range, thumb) to a hidden `<input type="range">`
+ * for form submission and accessibility.
+ *
+ * The hidden input stores the value for form submission. The thumb element has
+ * `role="slider"` with ARIA attributes for screen readers. Mouse drag, touch drag,
+ * track click, and keyboard navigation all update both the visual position and the
+ * hidden input value.
+ *
+ * @example
+ *   <div data-controller="kiso--slider"
+ *        data-kiso--slider-min-value="0"
+ *        data-kiso--slider-max-value="100"
+ *        data-kiso--slider-step-value="1">
+ *     <input type="range" data-kiso--slider-target="input" class="sr-only"
+ *            min="0" max="100" step="1" value="50">
+ *     <div data-kiso--slider-target="track" data-slot="slider-track">
+ *       <div data-kiso--slider-target="range" data-slot="slider-range"
+ *            style="width: 50%"></div>
+ *     </div>
+ *     <div data-kiso--slider-target="thumb" data-slot="slider-thumb"
+ *          role="slider" tabindex="0"
+ *          aria-valuemin="0" aria-valuemax="100" aria-valuenow="50"
+ *          style="position: absolute; left: 50%"></div>
+ *   </div>
+ *
+ * @property {HTMLInputElement} inputTarget - The hidden range input for form submission
+ * @property {HTMLElement} trackTarget - The background track element
+ * @property {HTMLElement} rangeTarget - The filled range portion
+ * @property {HTMLElement} thumbTarget - The draggable thumb handle
+ * @property {Number} minValue - Minimum slider value
+ * @property {Number} maxValue - Maximum slider value
+ * @property {Number} stepValue - Step increment
+ *
+ * @fires kiso--slider:change - When the slider value changes.
+ *   Detail: `{ value: number }`
+ */
+export default class extends Controller {
+  static targets = ["input", "track", "range", "thumb"]
+  static values = {
+    min: { type: Number, default: 0 },
+    max: { type: Number, default: 100 },
+    step: { type: Number, default: 1 },
+  }
+
+  /**
+   * Binds event listeners for mouse, touch, keyboard, and track click.
+   */
+  connect() {
+    this._handleMouseDown = this._handleMouseDown.bind(this)
+    this._handleMouseMove = this._handleMouseMove.bind(this)
+    this._handleMouseUp = this._handleMouseUp.bind(this)
+    this._handleTouchStart = this._handleTouchStart.bind(this)
+    this._handleTouchMove = this._handleTouchMove.bind(this)
+    this._handleTouchEnd = this._handleTouchEnd.bind(this)
+    this._handleTrackClick = this._handleTrackClick.bind(this)
+    this._handleKeyDown = this._handleKeyDown.bind(this)
+
+    this.thumbTarget.addEventListener("mousedown", this._handleMouseDown)
+    this.thumbTarget.addEventListener("touchstart", this._handleTouchStart, { passive: false })
+    this.thumbTarget.addEventListener("keydown", this._handleKeyDown)
+    this.trackTarget.addEventListener("click", this._handleTrackClick)
+
+    this._dragging = false
+  }
+
+  /**
+   * Removes all event listeners.
+   */
+  disconnect() {
+    this.thumbTarget.removeEventListener("mousedown", this._handleMouseDown)
+    this.thumbTarget.removeEventListener("touchstart", this._handleTouchStart)
+    this.thumbTarget.removeEventListener("keydown", this._handleKeyDown)
+    this.trackTarget.removeEventListener("click", this._handleTrackClick)
+
+    // Clean up any lingering global listeners from an interrupted drag
+    document.removeEventListener("mousemove", this._handleMouseMove)
+    document.removeEventListener("mouseup", this._handleMouseUp)
+    document.removeEventListener("touchmove", this._handleTouchMove)
+    document.removeEventListener("touchend", this._handleTouchEnd)
+  }
+
+  /**
+   * @returns {boolean} Whether the slider is disabled
+   * @private
+   */
+  get _isDisabled() {
+    return this.inputTarget.disabled
+  }
+
+  /**
+   * Starts mouse drag tracking.
+   *
+   * @param {MouseEvent} event
+   * @private
+   */
+  _handleMouseDown(event) {
+    if (this._isDisabled) return
+    event.preventDefault()
+
+    this._dragging = true
+    document.addEventListener("mousemove", this._handleMouseMove)
+    document.addEventListener("mouseup", this._handleMouseUp)
+    this.thumbTarget.focus()
+  }
+
+  /**
+   * Updates slider position during mouse drag.
+   *
+   * @param {MouseEvent} event
+   * @private
+   */
+  _handleMouseMove(event) {
+    if (!this._dragging) return
+    this._updateFromPointer(event.clientX)
+  }
+
+  /**
+   * Ends mouse drag tracking.
+   *
+   * @private
+   */
+  _handleMouseUp() {
+    this._dragging = false
+    document.removeEventListener("mousemove", this._handleMouseMove)
+    document.removeEventListener("mouseup", this._handleMouseUp)
+  }
+
+  /**
+   * Starts touch drag tracking.
+   *
+   * @param {TouchEvent} event
+   * @private
+   */
+  _handleTouchStart(event) {
+    if (this._isDisabled) return
+    event.preventDefault()
+
+    this._dragging = true
+    document.addEventListener("touchmove", this._handleTouchMove, { passive: false })
+    document.addEventListener("touchend", this._handleTouchEnd)
+    this.thumbTarget.focus()
+  }
+
+  /**
+   * Updates slider position during touch drag.
+   *
+   * @param {TouchEvent} event
+   * @private
+   */
+  _handleTouchMove(event) {
+    if (!this._dragging) return
+    event.preventDefault()
+    this._updateFromPointer(event.touches[0].clientX)
+  }
+
+  /**
+   * Ends touch drag tracking.
+   *
+   * @private
+   */
+  _handleTouchEnd() {
+    this._dragging = false
+    document.removeEventListener("touchmove", this._handleTouchMove)
+    document.removeEventListener("touchend", this._handleTouchEnd)
+  }
+
+  /**
+   * Jumps the thumb to the clicked position on the track.
+   *
+   * @param {MouseEvent} event
+   * @private
+   */
+  _handleTrackClick(event) {
+    if (this._isDisabled) return
+    this._updateFromPointer(event.clientX)
+    this.thumbTarget.focus()
+  }
+
+  /**
+   * Handles keyboard navigation on the thumb.
+   *
+   * Arrow keys adjust by step, Page Up/Down by 10x step, Home/End jump to min/max.
+   *
+   * @param {KeyboardEvent} event
+   * @private
+   */
+  _handleKeyDown(event) {
+    if (this._isDisabled) return
+
+    const current = parseFloat(this.inputTarget.value)
+    const step = this.stepValue
+    let newValue = current
+
+    switch (event.key) {
+      case "ArrowRight":
+      case "ArrowUp":
+        newValue = current + step
+        break
+      case "ArrowLeft":
+      case "ArrowDown":
+        newValue = current - step
+        break
+      case "PageUp":
+        newValue = current + step * 10
+        break
+      case "PageDown":
+        newValue = current - step * 10
+        break
+      case "Home":
+        newValue = this.minValue
+        break
+      case "End":
+        newValue = this.maxValue
+        break
+      default:
+        return
+    }
+
+    event.preventDefault()
+    this._setValue(newValue)
+  }
+
+  /**
+   * Calculates value from a pointer's X coordinate relative to the track.
+   *
+   * @param {number} clientX - The pointer's X coordinate
+   * @private
+   */
+  _updateFromPointer(clientX) {
+    const rect = this.trackTarget.getBoundingClientRect()
+    const ratio = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width))
+    const rawValue = this.minValue + ratio * (this.maxValue - this.minValue)
+    this._setValue(rawValue)
+  }
+
+  /**
+   * Snaps a value to the nearest step, clamps to min/max, and updates
+   * the hidden input, visual position, and ARIA attributes.
+   *
+   * @param {number} rawValue - The unsnapped value
+   * @private
+   */
+  _setValue(rawValue) {
+    const step = this.stepValue
+    const snapped = Math.round(rawValue / step) * step
+    const clamped = Math.max(this.minValue, Math.min(this.maxValue, snapped))
+
+    // Round to avoid floating point artifacts
+    const decimals = step.toString().includes(".") ? step.toString().split(".")[1].length : 0
+    const value = parseFloat(clamped.toFixed(decimals))
+
+    if (parseFloat(this.inputTarget.value) === value) return
+
+    this.inputTarget.value = value
+    this._updateVisual(value)
+
+    this.dispatch("change", { detail: { value } })
+  }
+
+  /**
+   * Updates the visual position of the range and thumb elements,
+   * and syncs ARIA attributes.
+   *
+   * @param {number} value - The current slider value
+   * @private
+   */
+  _updateVisual(value) {
+    const percent = ((value - this.minValue) / (this.maxValue - this.minValue)) * 100
+    this.rangeTarget.style.width = `${percent}%`
+    this.thumbTarget.style.left = `${percent}%`
+    this.thumbTarget.setAttribute("aria-valuenow", value)
+  }
+}

--- a/app/views/kiso/components/_slider.html.erb
+++ b/app/views/kiso/components/_slider.html.erb
@@ -1,0 +1,42 @@
+<%# locals: (min: 0, max: 100, step: 1, value: nil, name: nil, id: nil, disabled: false, size: :md, aria_label: nil, css_classes: "", **component_options) %>
+<% slider_value = value || min %>
+<% percent = ((slider_value.to_f - min) / (max - min) * 100).clamp(0, 100) %>
+<%= content_tag :div,
+    class: Kiso::Themes::Slider.render(class: css_classes),
+    data: kiso_prepare_options(component_options, slot: "slider",
+      controller: "kiso--slider",
+      kiso__slider_min_value: min,
+      kiso__slider_max_value: max,
+      kiso__slider_step_value: step),
+    **component_options do %>
+  <%= tag.input(type: :range,
+      id: id,
+      name: name,
+      min: min,
+      max: max,
+      step: step,
+      value: slider_value,
+      disabled: disabled,
+      aria: { label: aria_label },
+      tabindex: "-1",
+      class: "sr-only",
+      data: { kiso__slider_target: "input" }) %>
+  <%= tag.div(
+      class: Kiso::Themes::SliderTrack.render(size: size),
+      data: { slot: "slider-track", kiso__slider_target: "track" }) do %>
+    <%= tag.div(
+        class: Kiso::Themes::SliderRange.render,
+        style: "width: #{percent}%",
+        data: { slot: "slider-range", kiso__slider_target: "range" }) %>
+  <% end %>
+  <%= tag.div(
+      class: Kiso::Themes::SliderThumb.render(size: size),
+      role: :slider,
+      tabindex: (disabled ? "-1" : "0"),
+      aria: { valuemin: min, valuemax: max, valuenow: slider_value,
+              label: aria_label,
+              disabled: (disabled || nil) },
+      style: "position: absolute; left: #{percent}%",
+      data: { slot: "slider-thumb", kiso__slider_target: "thumb",
+              disabled: (disabled ? "true" : nil) }) %>
+<% end %>

--- a/docs/src/_data/navigation.yml
+++ b/docs/src/_data/navigation.yml
@@ -92,6 +92,8 @@ docs:
         href: /components/radio_group
       - title: Select
         href: /components/select
+      - title: Slider
+        href: /components/slider
       - title: Textarea
         href: /components/textarea
       - title: InputGroup

--- a/docs/src/components/slider.md
+++ b/docs/src/components/slider.md
@@ -1,0 +1,144 @@
+---
+title: Slider
+layout: docs
+description: An input where the user selects a value from within a given range.
+category: Form
+source: lib/kiso/themes/slider.rb
+---
+
+## Quick Start
+
+```erb
+<%%= kui(:slider, value: 75, max: 100, step: 1) %>
+```
+
+<%= render "component_preview", component: "kiso/form/slider", scenario: "playground", height: "100px" %>
+
+## Locals
+
+| Local | Type | Default |
+|-------|------|---------|
+| `min:` | Integer | `0` |
+| `max:` | Integer | `100` |
+| `step:` | Integer | `1` |
+| `value:` | Integer | `nil` (uses `min`) |
+| `name:` | String | `nil` |
+| `id:` | String | `nil` |
+| `disabled:` | Boolean | `false` |
+| `size:` | `:sm` \| `:md` \| `:lg` | `:md` |
+| `css_classes:` | String | `""` |
+| `**component_options` | Hash | `{}` |
+
+## Anatomy
+
+```
+Slider (root)
+├── input[type=range]    (hidden, form submission)
+├── Slider Track         (background track)
+│   └── Slider Range     (filled portion)
+└── Slider Thumb         (draggable handle)
+```
+
+## Usage
+
+### Size
+
+Use the `size:` local to change the track height and thumb size.
+
+```erb
+<%%= kui(:slider, size: :sm, value: 50) %>
+<%%= kui(:slider, size: :md, value: 50) %>
+<%%= kui(:slider, size: :lg, value: 50) %>
+```
+
+| Size | Track height | Thumb size |
+|------|-------------|------------|
+| `:sm` | `h-1` | `size-3` |
+| `:md` (default) | `h-1.5` | `size-4` |
+| `:lg` | `h-2` | `size-5` |
+
+### Step Values
+
+Use `min:`, `max:`, and `step:` to control the range and precision.
+
+```erb
+<%%= kui(:slider, min: 0, max: 1, step: 0.1, value: 0.5) %>
+```
+
+### Disabled
+
+Use `disabled: true` to prevent interaction. The slider appears at 50% opacity.
+
+```erb
+<%%= kui(:slider, value: 50, disabled: true) %>
+```
+
+### With Field
+
+Compose with a Field and Label for form usage.
+
+```erb
+<%%= kui(:field) do %>
+  <%%= kui(:field, :label, for: :volume) { "Volume" } %>
+  <%%= kui(:slider, id: :volume, name: :volume, value: 33) %>
+<%% end %>
+```
+
+### Form Submission
+
+Include `name:` to submit the value with a form. The hidden `<input type="range">`
+carries the value.
+
+```erb
+<%%= form_with url: "/settings" do |f| %>
+  <%%= kui(:slider, name: "settings[brightness]", value: 80, min: 0, max: 100) %>
+<%% end %>
+```
+
+## Theme
+
+```ruby
+Kiso::Themes::Slider = ClassVariants.build(
+  base: "relative flex w-full touch-none items-center select-none"
+)
+
+SliderTrack = ClassVariants.build(
+  base: "relative grow cursor-pointer overflow-hidden rounded-full bg-muted w-full",
+  variants: { size: { sm: "h-1", md: "h-1.5", lg: "h-2" } },
+  defaults: { size: :md }
+)
+
+SliderRange = ClassVariants.build(
+  base: "absolute h-full bg-primary"
+)
+
+SliderThumb = ClassVariants.build(
+  base: "block shrink-0 rounded-full border border-primary bg-white shadow-sm ...",
+  variants: { size: { sm: "size-3", md: "size-4", lg: "size-5" } },
+  defaults: { size: :md }
+)
+```
+
+## Accessibility
+
+| Attribute | Value |
+|-----------|-------|
+| `role` | `slider` (on thumb) |
+| `aria-valuemin` | Minimum value |
+| `aria-valuemax` | Maximum value |
+| `aria-valuenow` | Current value |
+| `data-slot` | `"slider"` |
+
+### Keyboard
+
+| Key | Action |
+|-----|--------|
+| `ArrowRight` / `ArrowUp` | Increase by step |
+| `ArrowLeft` / `ArrowDown` | Decrease by step |
+| `PageUp` | Increase by 10x step |
+| `PageDown` | Decrease by 10x step |
+| `Home` | Jump to minimum |
+| `End` | Jump to maximum |
+
+The slider dispatches a `kiso--slider:change` custom event with `{ value }` detail
+on every value change. Use Stimulus actions to react to changes.

--- a/lib/kiso.rb
+++ b/lib/kiso.rb
@@ -43,6 +43,7 @@ require "kiso/themes/color_mode_select"
 require "kiso/themes/dashboard"
 require "kiso/themes/nav"
 require "kiso/themes/avatar"
+require "kiso/themes/slider"
 require "kiso/icons"
 
 # Kiso — a Rails engine providing UI components inspired by shadcn/ui and Nuxt UI.

--- a/lib/kiso/themes/slider.rb
+++ b/lib/kiso/themes/slider.rb
@@ -1,0 +1,53 @@
+module Kiso
+  module Themes
+    # Range slider with track, filled range, and draggable thumb.
+    #
+    # @example
+    #   Slider.render(size: :md)
+    #
+    # Variants:
+    # - +size+ — :sm, :md (default), :lg
+    #
+    # Sub-parts: {SliderTrack}, {SliderRange}, {SliderThumb}
+    #
+    # shadcn base: relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50
+    Slider = ClassVariants.build(
+      base: "relative flex w-full touch-none items-center select-none"
+    )
+
+    # shadcn: relative grow overflow-hidden rounded-full bg-muted h-1.5 w-full
+    SliderTrack = ClassVariants.build(
+      base: "relative grow cursor-pointer overflow-hidden rounded-full bg-muted w-full",
+      variants: {
+        size: {
+          sm: "h-1",
+          md: "h-1.5",
+          lg: "h-2"
+        }
+      },
+      defaults: {size: :md}
+    )
+
+    # shadcn: absolute h-full bg-primary
+    SliderRange = ClassVariants.build(
+      base: "absolute h-full bg-primary"
+    )
+
+    # shadcn: block size-4 shrink-0 rounded-full border border-primary bg-white shadow-sm
+    #         ring-ring/50 transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4
+    #         focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50
+    SliderThumb = ClassVariants.build(
+      base: "block shrink-0 rounded-full border border-primary bg-white shadow-sm " \
+            "ring-ring/50 transition-[color,box-shadow] hover:ring-4 " \
+            "focus-visible:ring-4 focus-visible:outline-hidden",
+      variants: {
+        size: {
+          sm: "size-3",
+          md: "size-4",
+          lg: "size-5"
+        }
+      },
+      defaults: {size: :md}
+    )
+  end
+end

--- a/skills/kiso/references/components.md
+++ b/skills/kiso/references/components.md
@@ -45,6 +45,7 @@ All colored components use **identical compound variant formulas** — see `proj
 | `radio_group` | `color` (7 colors). Sub-part: item | [radio_group.md](components/radio_group.md) |
 | `combobox` | `name`, `multiple`. Sub-parts: input, content, list, item, empty, group, label, separator, chips, chip, chips_input. Stimulus: `kiso--combobox` | [combobox.md](components/combobox.md) |
 | `select` | `name`, `size` (sm/md). Sub-parts: trigger, value, content, group, label, item, separator. Stimulus: `kiso--select` | [select.md](components/select.md) |
+| `slider` | `min`, `max`, `step`, `value`, `size` (sm/md/lg), `disabled`. Stimulus: `kiso--slider` | [slider.md](components/slider.md) |
 | `switch` | `color` (7 colors), `size` (sm/md), `checked` | [switch.md](components/switch.md) |
 
 ## Overlay

--- a/skills/kiso/references/components/slider.md
+++ b/skills/kiso/references/components/slider.md
@@ -1,0 +1,25 @@
+# Slider
+
+A range input where the user selects a value by dragging a thumb along a track. Uses a hidden `<input type="range">` for form submission and a visual overlay with `role="slider"` on the thumb for accessibility. Stimulus controller handles drag, keyboard, and track click.
+
+**Locals:** `min:` (0), `max:` (100), `step:` (1), `value:` (nil), `name:`, `id:`, `disabled:` (false), `size:` (sm/md/lg), `css_classes:`, `**component_options`
+
+**Defaults:** `size: :md, min: 0, max: 100, step: 1`
+
+```erb
+<%= kui(:slider) %>
+<%= kui(:slider, value: 75, max: 100, step: 1) %>
+<%= kui(:slider, size: :sm, value: 50) %>
+<%= kui(:slider, min: 0, max: 1, step: 0.1, value: 0.5) %>
+<%= kui(:slider, disabled: true, value: 50) %>
+
+<%# With Field %>
+<%= kui(:field) do %>
+  <%= kui(:field, :label, for: :volume) { "Volume" } %>
+  <%= kui(:slider, id: :volume, name: :volume, value: 33) %>
+<% end %>
+```
+
+**Theme modules:** `Kiso::Themes::Slider`, `SliderTrack`, `SliderRange`, `SliderThumb` (`lib/kiso/themes/slider.rb`)
+
+**Stimulus:** `kiso--slider` controller. Dispatches `kiso--slider:change` with `{ value }` detail. Keyboard: Arrow keys (+/-step), Page Up/Down (+/-10x step), Home/End (min/max).

--- a/test/components/previews/kiso/slider_preview.rb
+++ b/test/components/previews/kiso/slider_preview.rb
@@ -1,0 +1,37 @@
+module Kiso
+  # @label Slider
+  # @logical_path kiso/form
+  class SliderPreview < Lookbook::Preview
+    # @label Playground
+    # @param size select { choices: [sm, md, lg] }
+    # @param value range { min: 0, max: 100, step: 1 }
+    # @param disabled toggle
+    def playground(size: :md, value: 75, disabled: false)
+      render_with_template(locals: {
+        size: size.to_sym,
+        value: value.to_i,
+        disabled: disabled
+      })
+    end
+
+    # @label Sizes
+    def sizes
+      render_with_template
+    end
+
+    # @label Disabled
+    def disabled
+      render_with_template
+    end
+
+    # @label With Field
+    def with_field
+      render_with_template
+    end
+
+    # @label Controlled
+    def controlled
+      render_with_template
+    end
+  end
+end

--- a/test/components/previews/kiso/slider_preview/controlled.html.erb
+++ b/test/components/previews/kiso/slider_preview/controlled.html.erb
@@ -1,0 +1,14 @@
+<div class="mx-auto grid w-full max-w-xs gap-3 text-foreground">
+  <div class="flex items-center justify-between gap-2">
+    <%= kui(:label, for: "slider-temperature") { "Temperature" } %>
+    <span class="text-sm text-muted-foreground">0.5</span>
+  </div>
+  <%= kui(:slider,
+      id: "slider-temperature",
+      min: 0,
+      max: 1,
+      step: 0.1,
+      value: 0.5,
+      name: "temperature",
+      aria_label: "Temperature") %>
+</div>

--- a/test/components/previews/kiso/slider_preview/disabled.html.erb
+++ b/test/components/previews/kiso/slider_preview/disabled.html.erb
@@ -1,0 +1,3 @@
+<div class="mx-auto flex w-full max-w-xs flex-col gap-3 text-foreground">
+  <%= kui(:slider, value: 50, disabled: true, aria_label: "Disabled slider") %>
+</div>

--- a/test/components/previews/kiso/slider_preview/playground.html.erb
+++ b/test/components/previews/kiso/slider_preview/playground.html.erb
@@ -1,0 +1,3 @@
+<div class="mx-auto flex w-full max-w-xs flex-col gap-3 text-foreground">
+  <%= kui(:slider, size: size, value: value, disabled: disabled, aria_label: "Volume") %>
+</div>

--- a/test/components/previews/kiso/slider_preview/sizes.html.erb
+++ b/test/components/previews/kiso/slider_preview/sizes.html.erb
@@ -1,0 +1,14 @@
+<div class="mx-auto flex w-full max-w-xs flex-col gap-6 text-foreground">
+  <div class="flex flex-col gap-2">
+    <span class="text-sm text-muted-foreground">Small</span>
+    <%= kui(:slider, size: :sm, value: 50, aria_label: "Small slider") %>
+  </div>
+  <div class="flex flex-col gap-2">
+    <span class="text-sm text-muted-foreground">Medium (default)</span>
+    <%= kui(:slider, size: :md, value: 50, aria_label: "Medium slider") %>
+  </div>
+  <div class="flex flex-col gap-2">
+    <span class="text-sm text-muted-foreground">Large</span>
+    <%= kui(:slider, size: :lg, value: 50, aria_label: "Large slider") %>
+  </div>
+</div>

--- a/test/components/previews/kiso/slider_preview/with_field.html.erb
+++ b/test/components/previews/kiso/slider_preview/with_field.html.erb
@@ -1,0 +1,6 @@
+<div class="mx-auto flex w-full max-w-xs flex-col gap-3 text-foreground">
+  <%= kui(:field) do %>
+    <%= kui(:field, :label, for: :volume) { "Volume" } %>
+    <%= kui(:slider, id: :volume, name: :volume, value: 33, max: 100, step: 1) %>
+  <% end %>
+</div>

--- a/test/e2e/components/slider.spec.js
+++ b/test/e2e/components/slider.spec.js
@@ -1,0 +1,173 @@
+import { test, expect } from "../fixtures/index.js"
+
+const BASE = "/preview/kiso/form/slider"
+
+test.describe("Slider component", () => {
+  // --- Rendering ---
+  test.describe("playground", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(`${BASE}/playground`)
+    })
+
+    test("renders with data-slot=slider", async ({ page }) => {
+      const slider = page.locator("[data-slot='slider']")
+      await expect(slider).toBeVisible()
+    })
+
+    test("renders track, range, and thumb sub-parts", async ({ page }) => {
+      await expect(page.locator("[data-slot='slider-track']")).toBeVisible()
+      await expect(page.locator("[data-slot='slider-range']")).toBeVisible()
+      await expect(page.locator("[data-slot='slider-thumb']")).toBeVisible()
+    })
+
+    test("thumb has role=slider with ARIA attributes", async ({ page }) => {
+      const thumb = page.locator("[data-slot='slider-thumb']")
+      await expect(thumb).toHaveAttribute("role", "slider")
+      await expect(thumb).toHaveAttribute("aria-valuemin", "0")
+      await expect(thumb).toHaveAttribute("aria-valuemax", "100")
+      await expect(thumb).toHaveAttribute("aria-valuenow")
+    })
+
+    test("contains a hidden range input", async ({ page }) => {
+      const input = page.locator("[data-slot='slider'] input[type='range']")
+      await expect(input).toHaveCount(1)
+    })
+
+    // --- Keyboard ---
+    test("ArrowRight increases value by step", async ({ page }) => {
+      const thumb = page.locator("[data-slot='slider-thumb']")
+      const input = page.locator("[data-slot='slider'] input[type='range']")
+
+      const initialValue = await input.inputValue()
+      await thumb.focus()
+      await page.keyboard.press("ArrowRight")
+
+      const newValue = await input.inputValue()
+      expect(Number(newValue)).toBe(Number(initialValue) + 1)
+    })
+
+    test("ArrowLeft decreases value by step", async ({ page }) => {
+      const thumb = page.locator("[data-slot='slider-thumb']")
+      const input = page.locator("[data-slot='slider'] input[type='range']")
+
+      const initialValue = await input.inputValue()
+      await thumb.focus()
+      await page.keyboard.press("ArrowLeft")
+
+      const newValue = await input.inputValue()
+      expect(Number(newValue)).toBe(Number(initialValue) - 1)
+    })
+
+    test("Home jumps to minimum value", async ({ page }) => {
+      const thumb = page.locator("[data-slot='slider-thumb']")
+      const input = page.locator("[data-slot='slider'] input[type='range']")
+
+      await thumb.focus()
+      await page.keyboard.press("Home")
+
+      const value = await input.inputValue()
+      expect(Number(value)).toBe(0)
+    })
+
+    test("End jumps to maximum value", async ({ page }) => {
+      const thumb = page.locator("[data-slot='slider-thumb']")
+      const input = page.locator("[data-slot='slider'] input[type='range']")
+
+      await thumb.focus()
+      await page.keyboard.press("End")
+
+      const value = await input.inputValue()
+      expect(Number(value)).toBe(100)
+    })
+
+    test("PageUp increases by 10x step", async ({ page }) => {
+      await page.goto(`${BASE}/playground?value=50`)
+      const thumb = page.locator("[data-slot='slider-thumb']")
+      const input = page.locator("[data-slot='slider'] input[type='range']")
+
+      await thumb.focus()
+      await page.keyboard.press("PageUp")
+
+      const value = await input.inputValue()
+      expect(Number(value)).toBe(60)
+    })
+
+    test("PageDown decreases by 10x step", async ({ page }) => {
+      await page.goto(`${BASE}/playground?value=50`)
+      const thumb = page.locator("[data-slot='slider-thumb']")
+      const input = page.locator("[data-slot='slider'] input[type='range']")
+
+      await thumb.focus()
+      await page.keyboard.press("PageDown")
+
+      const value = await input.inputValue()
+      expect(Number(value)).toBe(40)
+    })
+
+    test("ARIA valuenow updates on keyboard change", async ({ page }) => {
+      const thumb = page.locator("[data-slot='slider-thumb']")
+
+      await thumb.focus()
+      await page.keyboard.press("End")
+
+      await expect(thumb).toHaveAttribute("aria-valuenow", "100")
+    })
+
+    // --- Event dispatch ---
+    test("dispatches kiso--slider:change on value change", async ({ page, captureEvent }) => {
+      const thumb = page.locator("[data-slot='slider-thumb']")
+
+      await thumb.focus()
+      const getValue = await captureEvent("[data-slot='slider']", "kiso--slider:change")
+      await page.keyboard.press("End")
+
+      const detail = await getValue()
+      expect(detail.value).toBe(100)
+    })
+
+    // --- Accessibility ---
+    test("passes WCAG 2.1 AA", async ({ checkA11y }) => {
+      const results = await checkA11y()
+      expect(results.violations).toEqual([])
+    })
+  })
+
+  // --- Sizes ---
+  test("renders different sizes", async ({ page }) => {
+    await page.goto(`${BASE}/sizes`)
+    const sliders = page.locator("[data-slot='slider']")
+    await expect(sliders).toHaveCount(3)
+  })
+
+  // --- Disabled ---
+  test("disabled slider prevents keyboard interaction", async ({ page }) => {
+    await page.goto(`${BASE}/disabled`)
+    const input = page.locator("[data-slot='slider'] input[type='range']")
+    await expect(input).toBeDisabled()
+
+    const thumb = page.locator("[data-slot='slider-thumb']")
+    const valueBefore = await input.inputValue()
+
+    // Try keyboard — should not change
+    await thumb.focus({ force: true })
+    await page.keyboard.press("ArrowRight")
+    const valueAfter = await input.inputValue()
+    expect(valueAfter).toBe(valueBefore)
+  })
+
+  // --- Track click ---
+  test("clicking track updates slider value", async ({ page }) => {
+    await page.goto(`${BASE}/playground?value=0`)
+    const track = page.locator("[data-slot='slider-track']")
+    const input = page.locator("[data-slot='slider'] input[type='range']")
+
+    // Click near the middle of the track
+    const box = await track.boundingBox()
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2)
+
+    const value = Number(await input.inputValue())
+    // Should be roughly 50 (mid-point click)
+    expect(value).toBeGreaterThan(30)
+    expect(value).toBeLessThan(70)
+  })
+})

--- a/test/e2e/dark-mode.spec.js
+++ b/test/e2e/dark-mode.spec.js
@@ -62,6 +62,7 @@ test.describe("Dark mode accessibility", () => {
     { name: "radio-group", url: "/preview/kiso/form/radio_group/playground" },
     { name: "select", url: "/preview/kiso/form/select/playground" },
     { name: "separator", url: "/preview/kiso/separator/playground" },
+    { name: "slider", url: "/preview/kiso/form/slider/playground" },
     { name: "stats-card", url: "/preview/kiso/stats_card/playground" },
     { name: "switch", url: "/preview/kiso/form/switch/playground" },
     { name: "table", url: "/preview/kiso/table/playground" },


### PR DESCRIPTION
## Summary
- Single-value range slider with visual track/range/thumb connected to a hidden `<input type="range">` via Stimulus controller
- Supports `size:` (sm/md/lg), `min:`/`max:`/`step:` configuration, `disabled:` state, and `aria_label:` for accessibility
- Stimulus controller (`kiso--slider`) handles mouse drag, touch drag, track click, and full keyboard navigation (Arrow keys, Page Up/Down, Home/End)
- Theme modules: `Slider`, `SliderTrack`, `SliderRange`, `SliderThumb` with size variants matching shadcn structure
- CSS file for thumb centering transform and disabled state opacity

Closes #145

## Test plan
- [x] All 5 Lookbook previews render (200): playground, sizes, disabled, with_field, controlled
- [x] Docs page loads (200)
- [x] 16 Playwright E2E tests pass (Tier 3: rendering, keyboard nav, ARIA state, event dispatch, track click, disabled, a11y)
- [x] WCAG 2.1 AA passes (axe-core scan)
- [x] Dark mode entry added to dark-mode.spec.js
- [x] `bundle exec standardrb --fix` -- clean
- [x] `npm run lint && npm run fmt:check` -- clean
- [x] `bundle exec rake test` -- 19 tests, 0 failures
- [x] `npm run test:unit` -- 21 tests pass
- [ ] Visual review in Lookbook