### PR TITLE
feat: Add Skeleton component

### DIFF
--- a/app/views/kiso/components/_skeleton.html.erb
+++ b/app/views/kiso/components/_skeleton.html.erb
@@ -1,0 +1,5 @@
+<%# locals: (css_classes: "", **component_options) %>
+<%= tag.div(
+    class: Kiso::Themes::Skeleton.render(class: css_classes),
+    data: kiso_prepare_options(component_options, slot: "skeleton"),
+    **component_options) %>

--- a/docs/src/_data/navigation.yml
+++ b/docs/src/_data/navigation.yml
@@ -71,6 +71,8 @@ docs:
         href: /components/popover
       - title: Separator
         href: /components/separator
+      - title: Skeleton
+        href: /components/skeleton
       - title: Stats Card
         href: /components/stats_card
       - title: Table

--- a/docs/src/components/skeleton.md
+++ b/docs/src/components/skeleton.md
@@ -1,0 +1,71 @@
+---
+title: Skeleton
+layout: docs
+description: A placeholder element displayed while content is loading.
+category: Layout
+source: lib/kiso/themes/skeleton.rb
+---
+
+## Quick Start
+
+```erb
+<%%= kui(:skeleton, css_classes: "h-4 w-[250px]") %>
+```
+
+<%= render "component_preview", component: "kiso/skeleton", scenario: "playground" %>
+
+## Locals
+
+| Local | Type | Default |
+|-------|------|---------|
+| `css_classes:` | `String` | `""` |
+| `**component_options` | `Hash` | `{}` |
+
+## Usage
+
+Skeleton has no variants. Control shape and size entirely through `css_classes:`.
+
+### Text Lines
+
+```erb
+<div class="flex flex-col gap-2">
+  <%%= kui(:skeleton, css_classes: "h-4 w-[250px]") %>
+  <%%= kui(:skeleton, css_classes: "h-4 w-[200px]") %>
+</div>
+```
+
+### Circle (Avatar Placeholder)
+
+```erb
+<%%= kui(:skeleton, css_classes: "h-12 w-12 rounded-full") %>
+```
+
+### Card Placeholder
+
+```erb
+<div class="flex items-center gap-4">
+  <%%= kui(:skeleton, css_classes: "h-12 w-12 rounded-full") %>
+  <div class="flex flex-col gap-2">
+    <%%= kui(:skeleton, css_classes: "h-4 w-[250px]") %>
+    <%%= kui(:skeleton, css_classes: "h-4 w-[200px]") %>
+  </div>
+</div>
+```
+
+## Theme
+
+```ruby
+# lib/kiso/themes/skeleton.rb
+Kiso::Themes::Skeleton = ClassVariants.build(
+  base: "animate-pulse rounded-md bg-elevated"
+)
+```
+
+## Accessibility
+
+| Attribute | Value |
+|-----------|-------|
+| `data-slot` | `"skeleton"` |
+
+Skeleton is a decorative element with no semantic role. Screen readers
+skip it automatically since it contains no text content.

--- a/lib/kiso.rb
+++ b/lib/kiso.rb
@@ -46,6 +46,7 @@ require "kiso/themes/color_mode_select"
 require "kiso/themes/dashboard"
 require "kiso/themes/nav"
 require "kiso/themes/avatar"
+require "kiso/themes/skeleton"
 require "kiso/themes/slider"
 require "kiso/icons"
 

--- a/lib/kiso/themes/skeleton.rb
+++ b/lib/kiso/themes/skeleton.rb
@@ -1,0 +1,16 @@
+module Kiso
+  module Themes
+    # Placeholder element displayed while content is loading.
+    #
+    # @example
+    #   Skeleton.render
+    #
+    # No variants — dimensions set by consumer via css_classes.
+    #
+    # shadcn base: animate-pulse rounded-md bg-accent
+    # Nuxt UI base: animate-pulse rounded-md bg-elevated
+    Skeleton = ClassVariants.build(
+      base: "animate-pulse rounded-md bg-elevated"
+    )
+  end
+end

--- a/skills/kiso/references/components.md
+++ b/skills/kiso/references/components.md
@@ -27,6 +27,7 @@ All colored components use **identical compound variant formulas** — see `proj
 | `stats_card` | `variant` (outline/soft/subtle) | [stats_card.md](components/stats_card.md) |
 | `stats_grid` | `columns` (1-4). Responsive grid wrapper for stats cards | [stats_card.md](components/stats_card.md) |
 | `separator` | `orientation` (horizontal/vertical), `decorative` | [separator.md](components/separator.md) |
+| `skeleton` | No variants. Loading placeholder with `animate-pulse`. Shape via `css_classes:` | [skeleton.md](components/skeleton.md) |
 | `table` | 7 sub-parts: header, body, footer, row, head, cell, caption | [table.md](components/table.md) |
 
 ## Forms

--- a/skills/kiso/references/components/skeleton.md
+++ b/skills/kiso/references/components/skeleton.md
@@ -1,0 +1,27 @@
+# Skeleton
+
+A placeholder element displayed while content is loading. Pure CSS shimmer
+animation, no variants.
+
+**Locals:** `css_classes:`, `**component_options`
+
+**Defaults:** none (shape and size set via `css_classes:`)
+
+```erb
+<%# Text line placeholder %>
+<%= kui(:skeleton, css_classes: "h-4 w-[250px]") %>
+
+<%# Circle (avatar placeholder) %>
+<%= kui(:skeleton, css_classes: "h-12 w-12 rounded-full") %>
+
+<%# Card placeholder %>
+<div class="flex items-center gap-4">
+  <%= kui(:skeleton, css_classes: "h-12 w-12 rounded-full") %>
+  <div class="flex flex-col gap-2">
+    <%= kui(:skeleton, css_classes: "h-4 w-[250px]") %>
+    <%= kui(:skeleton, css_classes: "h-4 w-[200px]") %>
+  </div>
+</div>
+```
+
+**Theme module:** `Kiso::Themes::Skeleton` (`lib/kiso/themes/skeleton.rb`)

--- a/test/components/previews/kiso/skeleton_preview.rb
+++ b/test/components/previews/kiso/skeleton_preview.rb
@@ -1,0 +1,14 @@
+module Kiso
+  # @label Skeleton
+  class SkeletonPreview < Lookbook::Preview
+    # @label Playground
+    def playground
+      render_with_template
+    end
+
+    # @label Card
+    def card
+      render_with_template
+    end
+  end
+end

--- a/test/components/previews/kiso/skeleton_preview/card.html.erb
+++ b/test/components/previews/kiso/skeleton_preview/card.html.erb
@@ -1,0 +1,7 @@
+<div class="flex items-center gap-4">
+  <%= kui(:skeleton, css_classes: "h-12 w-12 rounded-full") %>
+  <div class="flex flex-col gap-2">
+    <%= kui(:skeleton, css_classes: "h-4 w-[250px]") %>
+    <%= kui(:skeleton, css_classes: "h-4 w-[200px]") %>
+  </div>
+</div>

--- a/test/components/previews/kiso/skeleton_preview/playground.html.erb
+++ b/test/components/previews/kiso/skeleton_preview/playground.html.erb
@@ -1,0 +1,6 @@
+<div class="flex flex-col gap-3">
+  <%= kui(:skeleton, css_classes: "h-4 w-[250px]") %>
+  <%= kui(:skeleton, css_classes: "h-4 w-[200px]") %>
+  <%= kui(:skeleton, css_classes: "h-4 w-[150px]") %>
+  <%= kui(:skeleton, css_classes: "h-12 w-12 rounded-full") %>
+</div>

--- a/test/e2e/dark-mode.spec.js
+++ b/test/e2e/dark-mode.spec.js
@@ -65,6 +65,7 @@ test.describe("Dark mode accessibility", () => {
     { name: "radio-group", url: "/preview/kiso/form/radio_group/playground" },
     { name: "select", url: "/preview/kiso/form/select/playground" },
     { name: "separator", url: "/preview/kiso/separator/playground" },
+    { name: "skeleton", url: "/preview/kiso/skeleton/playground" },
     { name: "slider", url: "/preview/kiso/form/slider/playground" },
     { name: "stats-card", url: "/preview/kiso/stats_card/playground" },
     { name: "switch", url: "/preview/kiso/form/switch/playground" },


### PR DESCRIPTION
## Summary

- Add `kui(:skeleton)` — a pure CSS loading placeholder with `animate-pulse` shimmer
- Single div, no variants, no Stimulus — dimensions controlled via `css_classes:`
- Minimal theme module (`bg-elevated` from Nuxt UI, `rounded-md` default)
- Lookbook previews (playground + card skeleton example)
- Docs page, skills reference, dark mode E2E entry

## Test plan

- [ ] `bundle exec rake test` passes
- [ ] `npm run lint && npm run fmt:check` clean
- [ ] Visual check in Lookbook (playground + card scenarios)
- [ ] Dark mode renders correctly
- [ ] `rounded-full` override works via `css_classes:`

Closes #153