### PR TITLE
fix: Replace v3 bracket syntax with v4 parentheses for CSS variable

### DIFF
--- a/docs/src/components/dashboard_group.md
+++ b/docs/src/components/dashboard_group.md
@@ -278,7 +278,7 @@ DashboardGroup = ClassVariants.build(
 
 DashboardNavbar = ClassVariants.build(
   base: "col-span-full flex items-center gap-3 px-4 border-b border-border
-         bg-background shrink-0 z-[--z-topbar]"
+         bg-background shrink-0 z-(--z-topbar)"
 )
 
 DashboardNavbarToggle = ClassVariants.build(

--- a/lib/kiso/themes/dashboard.rb
+++ b/lib/kiso/themes/dashboard.rb
@@ -5,7 +5,7 @@ module Kiso
     )
 
     DashboardNavbar = ClassVariants.build(
-      base: "flex items-center gap-3 px-4 border-b border-border bg-background shrink-0 z-[--z-topbar]"
+      base: "flex items-center gap-3 px-4 border-b border-border bg-background shrink-0 z-(--z-topbar)"
     )
 
     DashboardNavbarToggle = ClassVariants.build(


### PR DESCRIPTION
## Summary

- Audited all hardcoded arbitrary values across theme modules, CSS files, previews, dummy app, and docs
- Fixed `z-[--z-topbar]` → `z-(--z-topbar)` in DashboardNavbar theme and docs — the v3 bracket syntax passes the value literally without `var()` in Tailwind v4

**Confirmed correct (matches shadcn source exactly):**
- `ring-[3px]` — 7 theme files, no Tailwind scale equivalent
- `rounded-[4px]` — checkbox
- `translate-y-[2px]` — table head/cell
- `max-w-[calc(100%-2rem)]` — dialog/alert_dialog content

## Test plan

- [x] `bundle exec rake test` — all pass
- [ ] Visual check in Lookbook (dashboard navbar z-index still works)

Closes #119