### PR TITLE
Avatar: auto-contrast text color for custom backgrounds

### DIFF
--- a/app/views/kiso/components/_avatar.html.erb
+++ b/app/views/kiso/components/_avatar.html.erb
@@ -1,7 +1,8 @@
 <%# locals: (src: nil, alt: "", text: nil, size: :md, color: nil, ui: {}, css_classes: "", **component_options) %>
+<% text_color = Kiso::ColorUtils.contrast_text_color(color) if color %>
 <%= content_tag :span,
     class: Kiso::Themes::Avatar.render(size: size, class: css_classes),
-    style: (color ? "background-color: #{color};" : nil),
+    style: (color ? "background-color: #{color}; color: #{text_color};" : nil),
     data: kiso_prepare_options(component_options, slot: "avatar", size: size),
     **component_options do %>
   <% content = capture { yield }.presence %>
@@ -10,7 +11,7 @@
   <% else %>
     <% if text.present? %>
       <% fallback_classes = ui[:fallback].to_s %>
-      <% fallback_classes = "bg-transparent text-inherit #{fallback_classes}" if color %>
+      <% fallback_classes = "bg-transparent #{fallback_classes}" if color %>
       <%= tag.span class: Kiso::Themes::AvatarFallback.render(size: size, class: fallback_classes),
           data: { slot: "avatar-fallback" } do %>
         <%= text %>

--- a/lib/kiso.rb
+++ b/lib/kiso.rb
@@ -3,6 +3,7 @@
 require "class_variants"
 require "tailwind_merge"
 require "kiso/version"
+require "kiso/color_utils"
 require "kiso/configuration"
 require "kiso/presets"
 require "kiso/theme_overrides"

--- a/lib/kiso/color_utils.rb
+++ b/lib/kiso/color_utils.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Kiso
+  module ColorUtils
+    module_function
+
+    # Returns "white" or "black" based on WCAG relative luminance.
+    # Accepts 3-digit (#abc) or 6-digit (#aabbcc) hex strings.
+    def contrast_text_color(hex)
+      hex = hex.delete("#")
+      hex = hex.chars.map { |c| c * 2 }.join if hex.length == 3
+
+      r, g, b = hex.scan(/../).map { |c| c.to_i(16) / 255.0 }
+      luminance = [r, g, b].map { |c|
+        (c <= 0.04045) ? c / 12.92 : ((c + 0.055) / 1.055)**2.4
+      }.then { |lr, lg, lb| 0.2126 * lr + 0.7152 * lg + 0.0722 * lb }
+
+      (luminance > 0.179) ? "black" : "white"
+    end
+  end
+end

--- a/test/kiso/color_utils_test.rb
+++ b/test/kiso/color_utils_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Kiso::ColorUtilsTest < ActiveSupport::TestCase
+  test "returns white for dark colors" do
+    assert_equal "white", Kiso::ColorUtils.contrast_text_color("#000000")
+    assert_equal "white", Kiso::ColorUtils.contrast_text_color("#1e3a5f")
+    assert_equal "white", Kiso::ColorUtils.contrast_text_color("#7c3aed") # violet-600
+    assert_equal "white", Kiso::ColorUtils.contrast_text_color("#dc2626") # red-600
+  end
+
+  test "returns black for light colors" do
+    assert_equal "black", Kiso::ColorUtils.contrast_text_color("#ffffff")
+    assert_equal "black", Kiso::ColorUtils.contrast_text_color("#eab308") # yellow-500
+    assert_equal "black", Kiso::ColorUtils.contrast_text_color("#84cc16") # lime-500
+    assert_equal "black", Kiso::ColorUtils.contrast_text_color("#22d3ee") # cyan-400
+  end
+
+  test "handles 3-digit hex" do
+    assert_equal "white", Kiso::ColorUtils.contrast_text_color("#000")
+    assert_equal "black", Kiso::ColorUtils.contrast_text_color("#fff")
+  end
+
+  test "handles hex without hash" do
+    assert_equal "white", Kiso::ColorUtils.contrast_text_color("000000")
+    assert_equal "black", Kiso::ColorUtils.contrast_text_color("ffffff")
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Kiso::ColorUtils.contrast_text_color(hex)` — computes WCAG-compliant black/white text color from a hex background using relative luminance
- Avatar partial now sets `color: white` or `color: black` as inline style alongside the custom `background-color` when `color:` prop is a hex string
- Removes `text-inherit` on custom-colored avatars which always inherited the page's dark text color

Closes #206

## Test plan

- [ ] `bundle exec rake test` — all pass (106 tests, including 4 new ColorUtils tests)
- [ ] Visual check in Lookbook custom_colors preview — dark backgrounds get white text, light backgrounds get black text
- [ ] Dark mode verified — inline styles are mode-independent, no change needed