### PR TITLE
fix: Mobile sidebar partial-width and auto-close on navigation

### DIFF
--- a/app/assets/tailwind/kiso/dashboard.css
+++ b/app/assets/tailwind/kiso/dashboard.css
@@ -203,20 +203,21 @@
      sidebar element switches to a fixed-position overlay that slides in from
      the left. A semi-transparent scrim appears behind it. */
   @media (max-width: 767px) {
-    /* Remove the sidebar column from the grid on mobile */
+    /* Remove the sidebar column from the grid on mobile.
+       --sidebar-mobile-width caps the sidebar so the scrim remains
+       visible and tappable for dismiss (#208). */
     [data-slot="dashboard-group"] {
+      --sidebar-mobile-width: min(var(--sidebar-width), 85dvw);
       grid-template-columns: 0 1fr;
     }
 
-    /* Sidebar becomes a fixed overlay that slides in from the left.
-       Uses --sidebar-width (default 16rem) capped at 85dvw so the scrim
-       remains visible and tappable for dismiss (#208). */
+    /* Sidebar becomes a fixed overlay that slides in from the left */
     [data-slot="dashboard-sidebar"] {
       position: fixed;
       inset-block: 0;
       inset-inline-start: 0;
       z-index: var(--z-sidebar);
-      width: min(var(--sidebar-width), 85dvw);
+      width: var(--sidebar-mobile-width);
       transform: translateX(-100%);
       transition: transform var(--sidebar-duration) var(--ease-out-expo);
     }
@@ -228,7 +229,7 @@
 
     /* Inner nav matches mobile sidebar width */
     [data-slot="dashboard-sidebar-inner"] {
-      width: min(var(--sidebar-width), 85dvw);
+      width: var(--sidebar-mobile-width);
     }
 
     /* Semi-transparent scrim behind the open sidebar overlay.

--- a/app/javascript/controllers/kiso/sidebar_controller.js
+++ b/app/javascript/controllers/kiso/sidebar_controller.js
@@ -50,7 +50,9 @@ export default class extends Controller {
    */
   connect() {
     this._handleNavClick = (event) => {
-      if (event.target.closest('[data-slot="nav-item"] a, [data-slot="nav-item"][href]')) {
+      // Matches both: nav-item that IS a link (current Kiso markup: <a data-slot="nav-item">)
+      // and a link nested inside a nav-item (defensive for host app customization)
+      if (event.target.closest('[data-slot="nav-item"][href], [data-slot="nav-item"] a')) {
         this.closeOnMobile()
       }
     }


### PR DESCRIPTION
## Summary

- **Partial-width sidebar (#208):** Mobile sidebar now uses `min(--sidebar-width, 85dvw)` instead of `100dvw`, leaving the scrim visible on the right edge so users can tap to dismiss. Follows the standard mobile drawer pattern (Material Design, iOS).
- **Auto-close on nav (#209):** Event delegation on the controller element detects clicks on `[data-slot="nav-item"]` links and calls `closeOnMobile()`, so the sidebar dismisses automatically after navigation.

Closes #208
Closes #209

## Test plan

- [ ] Open sidebar on mobile viewport — should be partial width (~85% max)
- [ ] Tap scrim area to the right of sidebar — should dismiss
- [ ] Tap a nav item link on mobile — sidebar should auto-close
- [ ] Desktop sidebar toggle still works normally (not affected)
- [ ] `bundle exec rake test` — passes
- [ ] `npm run lint && npm run fmt:check` — clean