### PR TITLE
Fix dropdown menu items wrapping text

### DIFF
--- a/lib/kiso/themes/dropdown_menu.rb
+++ b/lib/kiso/themes/dropdown_menu.rb
@@ -21,7 +21,7 @@ module Kiso
 
     # The dropdown panel containing menu items.
     DropdownMenuContent = ClassVariants.build(
-      base: "bg-background text-foreground z-50 min-w-32 " \
+      base: "bg-background text-foreground z-50 min-w-32 whitespace-nowrap " \
             "overflow-x-hidden overflow-y-auto rounded-md ring ring-inset ring-border p-1 shadow-md"
     )
 
@@ -101,7 +101,7 @@ module Kiso
 
     # Panel for nested sub-menu items (same as {DropdownMenuContent} but +shadow-lg+).
     DropdownMenuSubContent = ClassVariants.build(
-      base: "bg-background text-foreground z-50 min-w-32 " \
+      base: "bg-background text-foreground z-50 min-w-32 whitespace-nowrap " \
             "overflow-hidden rounded-md ring ring-inset ring-border p-1 shadow-lg"
     )
   end


### PR DESCRIPTION
## Summary

- Add `whitespace-nowrap` to `DropdownMenuContent` and `DropdownMenuSubContent` themes
- Menu items are single-line labels by convention — they should never wrap

## Test plan

- [x] All 118 tests pass
- [ ] Visual verify in Lookbook dropdown menu preview

Closes #221