### PR TITLE
fix: Forward HTML form= attribute on plain <button> elements

### DIFF
--- a/app/views/kiso/components/_button.html.erb
+++ b/app/views/kiso/components/_button.html.erb
@@ -37,7 +37,8 @@
   <% end %>
 <% else %>
   <% component_options[:type] = type
-     component_options[:disabled] = true if is_disabled %>
+     component_options[:disabled] = true if is_disabled
+     component_options[:form] = form if form.is_a?(String) %>
   <%= content_tag :button, class: css, data: data, **component_options do %>
     <%= kiso_component_icon(:spinner, class: "animate-spin") if loading %>
     <%= yield %>


### PR DESCRIPTION
## Summary
- Forward `form:` as an HTML attribute when it's a String (e.g., `form: "my-form-id"`)
- Existing Hash behavior for `button_to` is unchanged

Closes #239